### PR TITLE
feat: Add public key retrieval for non-custodial tool calls (CSS-195)

### DIFF
--- a/src/langchain/tools/hbar/get_hbar_balance_tool.ts
+++ b/src/langchain/tools/hbar/get_hbar_balance_tool.ts
@@ -31,11 +31,17 @@ If no input is given (empty JSON '{}'), it returns the balance of the connected 
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-              isCustodial,
-              executorAccountDetails,
-              this.hederaKit.network
-            );
+            if (!isCustodial && !executorAccountDetails) {
+                throw new Error("Executor account details are required for non-custodial mode.");
+            }
+
+            if (executorAccountDetails) {
+                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+                  isCustodial,
+                  executorAccountDetails,
+                  this.hederaKit.network
+                );
+            }
 
             console.log('hedera_get_hbar_balance tool has been called')
 

--- a/src/langchain/tools/hbar/get_hbar_balance_tool.ts
+++ b/src/langchain/tools/hbar/get_hbar_balance_tool.ts
@@ -1,8 +1,7 @@
 import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { ExecutorAccountDetails } from "../../../types";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
 
 export class HederaGetBalanceTool extends Tool {
     name = 'hedera_get_hbar_balance'
@@ -29,19 +28,11 @@ If no input is given (empty JSON '{}'), it returns the balance of the connected 
     protected override async _call(input: any, _runManager?: CallbackManagerForToolRun, config?: ToolRunnableConfig): Promise<string> {
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
-            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-            if (!isCustodial && !executorAccountDetails) {
-                throw new Error("Executor account details are required for non-custodial mode.");
-            }
-
-            if (executorAccountDetails) {
-                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-                  isCustodial,
-                  executorAccountDetails,
-                  this.hederaKit.network
-                );
-            }
+            const executorAccountDetails = await prepareExecutorAccountDetails(
+              isCustodial,
+              config?.configurable?.executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log('hedera_get_hbar_balance tool has been called')
 

--- a/src/langchain/tools/hbar/get_hbar_balance_tool.ts
+++ b/src/langchain/tools/hbar/get_hbar_balance_tool.ts
@@ -2,6 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 export class HederaGetBalanceTool extends Tool {
     name = 'hedera_get_hbar_balance'
@@ -29,6 +30,16 @@ If no input is given (empty JSON '{}'), it returns the balance of the connected 
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+                if (!executorAccountDetails.executorAccountId)
+                    throw new Error("Executor account ID is required for non-custodial mode");
+
+                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+                  this.hederaKit.network,
+                  executorAccountDetails.executorAccountId
+                );
+            }
 
             console.log('hedera_get_hbar_balance tool has been called')
 

--- a/src/langchain/tools/hbar/get_hbar_balance_tool.ts
+++ b/src/langchain/tools/hbar/get_hbar_balance_tool.ts
@@ -2,7 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
-import { getPublicKeyByAccountId } from "../../../utils/api-utils";
+import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
 
 export class HederaGetBalanceTool extends Tool {
     name = 'hedera_get_hbar_balance'
@@ -31,15 +31,11 @@ If no input is given (empty JSON '{}'), it returns the balance of the connected 
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-                if (!executorAccountDetails.executorAccountId)
-                    throw new Error("Executor account ID is required for non-custodial mode");
-
-                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
-                  this.hederaKit.network,
-                  executorAccountDetails.executorAccountId
-                );
-            }
+            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+              isCustodial,
+              executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log('hedera_get_hbar_balance tool has been called')
 

--- a/src/langchain/tools/hbar/transfer_native_hbar_token_tool.ts
+++ b/src/langchain/tools/hbar/transfer_native_hbar_token_tool.ts
@@ -28,11 +28,17 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-              isCustodial,
-              executorAccountDetails,
-              this.hederaKit.network
-            );
+            if (!isCustodial && !executorAccountDetails) {
+                throw new Error("Executor account details are required for non-custodial mode.");
+            }
+
+            if (executorAccountDetails) {
+                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+                  isCustodial,
+                  executorAccountDetails,
+                  this.hederaKit.network
+                );
+            }
 
             console.log(`hedera_transfer_native_hbar_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hbar/transfer_native_hbar_token_tool.ts
+++ b/src/langchain/tools/hbar/transfer_native_hbar_token_tool.ts
@@ -1,8 +1,7 @@
 import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { ExecutorAccountDetails } from "../../../types";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
 
 export class HederaTransferHbarTool extends Tool {
     name = 'hedera_transfer_native_hbar_token';
@@ -26,19 +25,11 @@ Example usage:
     protected override async _call(input: any, _runManager?: CallbackManagerForToolRun, config?: ToolRunnableConfig): Promise<string> {
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
-            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-            if (!isCustodial && !executorAccountDetails) {
-                throw new Error("Executor account details are required for non-custodial mode.");
-            }
-
-            if (executorAccountDetails) {
-                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-                  isCustodial,
-                  executorAccountDetails,
-                  this.hederaKit.network
-                );
-            }
+            const executorAccountDetails = await prepareExecutorAccountDetails(
+              isCustodial,
+              config?.configurable?.executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_transfer_native_hbar_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hbar/transfer_native_hbar_token_tool.ts
+++ b/src/langchain/tools/hbar/transfer_native_hbar_token_tool.ts
@@ -2,7 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
-import { getPublicKeyByAccountId } from "../../../utils/api-utils";
+import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
 
 export class HederaTransferHbarTool extends Tool {
     name = 'hedera_transfer_native_hbar_token';
@@ -28,15 +28,11 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-                if (!executorAccountDetails.executorAccountId)
-                    throw new Error("Executor account ID is required for non-custodial mode");
-
-                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
-                  this.hederaKit.network,
-                  executorAccountDetails.executorAccountId
-                );
-            }
+            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+              isCustodial,
+              executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_transfer_native_hbar_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hbar/transfer_native_hbar_token_tool.ts
+++ b/src/langchain/tools/hbar/transfer_native_hbar_token_tool.ts
@@ -2,6 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 export class HederaTransferHbarTool extends Tool {
     name = 'hedera_transfer_native_hbar_token';
@@ -26,6 +27,16 @@ Example usage:
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+                if (!executorAccountDetails.executorAccountId)
+                    throw new Error("Executor account ID is required for non-custodial mode");
+
+                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+                  this.hederaKit.network,
+                  executorAccountDetails.executorAccountId
+                );
+            }
 
             console.log(`hedera_transfer_native_hbar_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hcs/create_topic_tool.ts
+++ b/src/langchain/tools/hcs/create_topic_tool.ts
@@ -2,7 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
-import { getPublicKeyByAccountId } from "../../../utils/api-utils";
+import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
 
 export class HederaCreateTopicTool extends Tool {
 
@@ -39,15 +39,11 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-                if (!executorAccountDetails.executorAccountId)
-                    throw new Error("Executor account ID is required for non-custodial mode");
-
-                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
-                  this.hederaKit.network,
-                  executorAccountDetails.executorAccountId
-                );
-            }
+            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+              isCustodial,
+              executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_create_topic tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hcs/create_topic_tool.ts
+++ b/src/langchain/tools/hcs/create_topic_tool.ts
@@ -1,8 +1,7 @@
 import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { ExecutorAccountDetails } from "../../../types";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
 
 export class HederaCreateTopicTool extends Tool {
 
@@ -37,19 +36,11 @@ Example usage:
     protected override async _call(input: any, _runManager?: CallbackManagerForToolRun, config?: ToolRunnableConfig):  Promise<string> {
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
-            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-            if (!isCustodial && !executorAccountDetails) {
-                throw new Error("Executor account details are required for non-custodial mode.");
-            }
-
-            if (executorAccountDetails) {
-                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-                  isCustodial,
-                  executorAccountDetails,
-                  this.hederaKit.network
-                );
-            }
+            const executorAccountDetails = await prepareExecutorAccountDetails(
+              isCustodial,
+              config?.configurable?.executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_create_topic tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hcs/create_topic_tool.ts
+++ b/src/langchain/tools/hcs/create_topic_tool.ts
@@ -2,6 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 export class HederaCreateTopicTool extends Tool {
 
@@ -37,6 +38,16 @@ Example usage:
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+                if (!executorAccountDetails.executorAccountId)
+                    throw new Error("Executor account ID is required for non-custodial mode");
+
+                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+                  this.hederaKit.network,
+                  executorAccountDetails.executorAccountId
+                );
+            }
 
             console.log(`hedera_create_topic tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hcs/create_topic_tool.ts
+++ b/src/langchain/tools/hcs/create_topic_tool.ts
@@ -39,11 +39,17 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-              isCustodial,
-              executorAccountDetails,
-              this.hederaKit.network
-            );
+            if (!isCustodial && !executorAccountDetails) {
+                throw new Error("Executor account details are required for non-custodial mode.");
+            }
+
+            if (executorAccountDetails) {
+                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+                  isCustodial,
+                  executorAccountDetails,
+                  this.hederaKit.network
+                );
+            }
 
             console.log(`hedera_create_topic tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hcs/delete_topic_tool.ts
+++ b/src/langchain/tools/hcs/delete_topic_tool.ts
@@ -2,8 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { TopicId } from "@hashgraph/sdk";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { ExecutorAccountDetails } from "../../../types";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
 
 export class HederaDeleteTopicTool extends Tool {
     name = 'hedera_delete_topic';
@@ -25,19 +24,11 @@ Example usage:
     protected override async _call(input: any, _runManager?: CallbackManagerForToolRun, config?: ToolRunnableConfig):  Promise<string> {
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
-            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-            if (!isCustodial && !executorAccountDetails) {
-                throw new Error("Executor account details are required for non-custodial mode.");
-            }
-
-            if (executorAccountDetails) {
-                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-                  isCustodial,
-                  executorAccountDetails,
-                  this.hederaKit.network
-                );
-            }
+            const executorAccountDetails = await prepareExecutorAccountDetails(
+              isCustodial,
+              config?.configurable?.executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_delete_topic tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hcs/delete_topic_tool.ts
+++ b/src/langchain/tools/hcs/delete_topic_tool.ts
@@ -3,6 +3,7 @@ import HederaAgentKit from "../../../agent";
 import { TopicId } from "@hashgraph/sdk";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 export class HederaDeleteTopicTool extends Tool {
     name = 'hedera_delete_topic';
@@ -25,6 +26,16 @@ Example usage:
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+                if (!executorAccountDetails.executorAccountId)
+                    throw new Error("Executor account ID is required for non-custodial mode");
+
+                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+                  this.hederaKit.network,
+                  executorAccountDetails.executorAccountId
+                );
+            }
 
             console.log(`hedera_delete_topic tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hcs/submit_topic_message_tool.ts
+++ b/src/langchain/tools/hcs/submit_topic_message_tool.ts
@@ -3,6 +3,7 @@ import HederaAgentKit from "../../../agent";
 import { TopicId } from "@hashgraph/sdk";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 export class HederaSubmitTopicMessageTool extends Tool {
     name = 'hedera_submit_topic_message';
@@ -27,6 +28,16 @@ Example usage:
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+                if (!executorAccountDetails.executorAccountId)
+                    throw new Error("Executor account ID is required for non-custodial mode");
+
+                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+                  this.hederaKit.network,
+                  executorAccountDetails.executorAccountId
+                );
+            }
 
             console.log(`hedera_submit_topic_message tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hcs/submit_topic_message_tool.ts
+++ b/src/langchain/tools/hcs/submit_topic_message_tool.ts
@@ -2,8 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { TopicId } from "@hashgraph/sdk";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { ExecutorAccountDetails } from "../../../types";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
 
 export class HederaSubmitTopicMessageTool extends Tool {
     name = 'hedera_submit_topic_message';
@@ -27,19 +26,11 @@ Example usage:
     protected override async _call(input: any, _runManager?: CallbackManagerForToolRun, config?: ToolRunnableConfig): Promise<string> {
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
-            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-            if (!isCustodial && !executorAccountDetails) {
-                throw new Error("Executor account details are required for non-custodial mode.");
-            }
-
-            if (executorAccountDetails) {
-                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-                  isCustodial,
-                  executorAccountDetails,
-                  this.hederaKit.network
-                );
-            }
+            const executorAccountDetails = await prepareExecutorAccountDetails(
+              isCustodial,
+              config?.configurable?.executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_submit_topic_message tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hcs/submit_topic_message_tool.ts
+++ b/src/langchain/tools/hcs/submit_topic_message_tool.ts
@@ -3,7 +3,7 @@ import HederaAgentKit from "../../../agent";
 import { TopicId } from "@hashgraph/sdk";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
-import { getPublicKeyByAccountId } from "../../../utils/api-utils";
+import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
 
 export class HederaSubmitTopicMessageTool extends Tool {
     name = 'hedera_submit_topic_message';
@@ -29,15 +29,11 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-                if (!executorAccountDetails.executorAccountId)
-                    throw new Error("Executor account ID is required for non-custodial mode");
-
-                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
-                  this.hederaKit.network,
-                  executorAccountDetails.executorAccountId
-                );
-            }
+            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+              isCustodial,
+              executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_submit_topic_message tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hcs/submit_topic_message_tool.ts
+++ b/src/langchain/tools/hcs/submit_topic_message_tool.ts
@@ -29,11 +29,17 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-              isCustodial,
-              executorAccountDetails,
-              this.hederaKit.network
-            );
+            if (!isCustodial && !executorAccountDetails) {
+                throw new Error("Executor account details are required for non-custodial mode.");
+            }
+
+            if (executorAccountDetails) {
+                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+                  isCustodial,
+                  executorAccountDetails,
+                  this.hederaKit.network
+                );
+            }
 
             console.log(`hedera_submit_topic_message tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/airdrop_token_tool.ts
+++ b/src/langchain/tools/hts/airdrop_token_tool.ts
@@ -1,10 +1,9 @@
 import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { ExecutorAccountDetails } from "../../../types";
 import { toBaseUnit } from "../../../utils/hts-format-utils";
 import { AirdropRecipient } from "../../../tools";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
 
 export class HederaAirdropTokenTool extends Tool {
     name = 'hedera_airdrop_token';
@@ -36,19 +35,11 @@ Example usage:
     ): Promise<string> {
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
-            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-            if (!isCustodial && !executorAccountDetails) {
-                throw new Error("Executor account details are required for non-custodial mode.");
-            }
-
-            if (executorAccountDetails) {
-                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-                  isCustodial,
-                  executorAccountDetails,
-                  this.hederaKit.network
-                );
-            }
+            const executorAccountDetails = await prepareExecutorAccountDetails(
+              isCustodial,
+              config?.configurable?.executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_airdrop_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/airdrop_token_tool.ts
+++ b/src/langchain/tools/hts/airdrop_token_tool.ts
@@ -38,11 +38,17 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-              isCustodial,
-              executorAccountDetails,
-              this.hederaKit.network
-            );
+            if (!isCustodial && !executorAccountDetails) {
+                throw new Error("Executor account details are required for non-custodial mode.");
+            }
+
+            if (executorAccountDetails) {
+                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+                  isCustodial,
+                  executorAccountDetails,
+                  this.hederaKit.network
+                );
+            }
 
             console.log(`hedera_airdrop_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/airdrop_token_tool.ts
+++ b/src/langchain/tools/hts/airdrop_token_tool.ts
@@ -3,8 +3,8 @@ import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
 import { toBaseUnit } from "../../../utils/hts-format-utils";
-import { AirdropRecipient } from "../../../tools/transactions/strategies";
-import { getPublicKeyByAccountId } from "../../../utils/api-utils";
+import { AirdropRecipient } from "../../../tools";
+import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
 
 export class HederaAirdropTokenTool extends Tool {
     name = 'hedera_airdrop_token';
@@ -38,15 +38,11 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-                if (!executorAccountDetails.executorAccountId)
-                    throw new Error("Executor account ID is required for non-custodial mode");
-
-                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
-                  this.hederaKit.network,
-                  executorAccountDetails.executorAccountId
-                );
-            }
+            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+              isCustodial,
+              executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_airdrop_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/airdrop_token_tool.ts
+++ b/src/langchain/tools/hts/airdrop_token_tool.ts
@@ -4,6 +4,7 @@ import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
 import { toBaseUnit } from "../../../utils/hts-format-utils";
 import { AirdropRecipient } from "../../../tools/transactions/strategies";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 export class HederaAirdropTokenTool extends Tool {
     name = 'hedera_airdrop_token';
@@ -36,6 +37,16 @@ Example usage:
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+                if (!executorAccountDetails.executorAccountId)
+                    throw new Error("Executor account ID is required for non-custodial mode");
+
+                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+                  this.hederaKit.network,
+                  executorAccountDetails.executorAccountId
+                );
+            }
 
             console.log(`hedera_airdrop_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/associate_token_tool.ts
+++ b/src/langchain/tools/hts/associate_token_tool.ts
@@ -26,11 +26,17 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-              isCustodial,
-              executorAccountDetails,
-              this.hederaKit.network
-            );
+            if (!isCustodial && !executorAccountDetails) {
+                throw new Error("Executor account details are required for non-custodial mode.");
+            }
+
+            if (executorAccountDetails) {
+                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+                  isCustodial,
+                  executorAccountDetails,
+                  this.hederaKit.network
+                );
+            }
 
             console.log(`hedera_associate_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/associate_token_tool.ts
+++ b/src/langchain/tools/hts/associate_token_tool.ts
@@ -2,6 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 export class HederaAssociateTokenTool extends Tool {
     name = 'hedera_associate_token';
@@ -24,6 +25,16 @@ Example usage:
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+                if (!executorAccountDetails.executorAccountId)
+                    throw new Error("Executor account ID is required for non-custodial mode");
+
+                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+                  this.hederaKit.network,
+                  executorAccountDetails.executorAccountId
+                );
+            }
 
             console.log(`hedera_associate_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/associate_token_tool.ts
+++ b/src/langchain/tools/hts/associate_token_tool.ts
@@ -2,7 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
-import { getPublicKeyByAccountId } from "../../../utils/api-utils";
+import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
 
 export class HederaAssociateTokenTool extends Tool {
     name = 'hedera_associate_token';
@@ -26,15 +26,11 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-                if (!executorAccountDetails.executorAccountId)
-                    throw new Error("Executor account ID is required for non-custodial mode");
-
-                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
-                  this.hederaKit.network,
-                  executorAccountDetails.executorAccountId
-                );
-            }
+            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+              isCustodial,
+              executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_associate_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/associate_token_tool.ts
+++ b/src/langchain/tools/hts/associate_token_tool.ts
@@ -1,8 +1,7 @@
 import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { ExecutorAccountDetails } from "../../../types";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
 
 export class HederaAssociateTokenTool extends Tool {
     name = 'hedera_associate_token';
@@ -24,19 +23,11 @@ Example usage:
     protected override async _call(input: any, _runManager?: CallbackManagerForToolRun, config?: ToolRunnableConfig): Promise<string> {
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
-            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-            if (!isCustodial && !executorAccountDetails) {
-                throw new Error("Executor account details are required for non-custodial mode.");
-            }
-
-            if (executorAccountDetails) {
-                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-                  isCustodial,
-                  executorAccountDetails,
-                  this.hederaKit.network
-                );
-            }
+            const executorAccountDetails = await prepareExecutorAccountDetails(
+              isCustodial,
+              config?.configurable?.executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_associate_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/claim_airdrop_tool.ts
+++ b/src/langchain/tools/hts/claim_airdrop_tool.ts
@@ -2,8 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { AccountId, PendingAirdropId, TokenId } from "@hashgraph/sdk";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { ExecutorAccountDetails } from "../../../types";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
 
 export class HederaClaimAirdropTool extends Tool {
     name = 'hedera_claim_airdrop';
@@ -27,19 +26,11 @@ Example usage:
     protected override async _call(input: any, _runManager?: CallbackManagerForToolRun, config?: ToolRunnableConfig): Promise<string> {
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
-            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-            if (!isCustodial && !executorAccountDetails) {
-                throw new Error("Executor account details are required for non-custodial mode.");
-            }
-
-            if (executorAccountDetails) {
-                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-                  isCustodial,
-                  executorAccountDetails,
-                  this.hederaKit.network
-                );
-            }
+            const executorAccountDetails = await prepareExecutorAccountDetails(
+              isCustodial,
+              config?.configurable?.executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_claim_airdrop tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/claim_airdrop_tool.ts
+++ b/src/langchain/tools/hts/claim_airdrop_tool.ts
@@ -29,11 +29,17 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-              isCustodial,
-              executorAccountDetails,
-              this.hederaKit.network
-            );
+            if (!isCustodial && !executorAccountDetails) {
+                throw new Error("Executor account details are required for non-custodial mode.");
+            }
+
+            if (executorAccountDetails) {
+                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+                  isCustodial,
+                  executorAccountDetails,
+                  this.hederaKit.network
+                );
+            }
 
             console.log(`hedera_claim_airdrop tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/claim_airdrop_tool.ts
+++ b/src/langchain/tools/hts/claim_airdrop_tool.ts
@@ -3,7 +3,7 @@ import HederaAgentKit from "../../../agent";
 import { AccountId, PendingAirdropId, TokenId } from "@hashgraph/sdk";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
-import { getPublicKeyByAccountId } from "../../../utils/api-utils";
+import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
 
 export class HederaClaimAirdropTool extends Tool {
     name = 'hedera_claim_airdrop';
@@ -29,15 +29,11 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-                if (!executorAccountDetails.executorAccountId)
-                    throw new Error("Executor account ID is required for non-custodial mode");
-
-                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
-                  this.hederaKit.network,
-                  executorAccountDetails.executorAccountId
-                );
-            }
+            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+              isCustodial,
+              executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_claim_airdrop tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/claim_airdrop_tool.ts
+++ b/src/langchain/tools/hts/claim_airdrop_tool.ts
@@ -3,6 +3,7 @@ import HederaAgentKit from "../../../agent";
 import { AccountId, PendingAirdropId, TokenId } from "@hashgraph/sdk";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 export class HederaClaimAirdropTool extends Tool {
     name = 'hedera_claim_airdrop';
@@ -27,6 +28,16 @@ Example usage:
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+                if (!executorAccountDetails.executorAccountId)
+                    throw new Error("Executor account ID is required for non-custodial mode");
+
+                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+                  this.hederaKit.network,
+                  executorAccountDetails.executorAccountId
+                );
+            }
 
             console.log(`hedera_claim_airdrop tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/create_fungible_token_tool.ts
+++ b/src/langchain/tools/hts/create_fungible_token_tool.ts
@@ -2,6 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 export class HederaCreateFungibleTokenTool extends Tool {
     name = 'hedera_create_fungible_token';
@@ -26,6 +27,16 @@ tokenMetadata: string, containing metadata associated with this token, empty str
         try {
            const isCustodial = config?.configurable?.isCustodial === true;
            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+          if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+            if (!executorAccountDetails.executorAccountId)
+              throw new Error("Executor account ID is required for non-custodial mode");
+
+            executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+              this.hederaKit.network,
+              executorAccountDetails.executorAccountId
+            );
+          }
 
            console.log(`hedera_create_fungible_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/create_fungible_token_tool.ts
+++ b/src/langchain/tools/hts/create_fungible_token_tool.ts
@@ -2,7 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
-import { getPublicKeyByAccountId } from "../../../utils/api-utils";
+import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
 
 export class HederaCreateFungibleTokenTool extends Tool {
     name = 'hedera_create_fungible_token';
@@ -28,15 +28,11 @@ tokenMetadata: string, containing metadata associated with this token, empty str
            const isCustodial = config?.configurable?.isCustodial === true;
            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-          if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-            if (!executorAccountDetails.executorAccountId)
-              throw new Error("Executor account ID is required for non-custodial mode");
-
-            executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
-              this.hederaKit.network,
-              executorAccountDetails.executorAccountId
-            );
-          }
+          executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+            isCustodial,
+            executorAccountDetails,
+            this.hederaKit.network
+          );
 
            console.log(`hedera_create_fungible_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/create_fungible_token_tool.ts
+++ b/src/langchain/tools/hts/create_fungible_token_tool.ts
@@ -1,8 +1,7 @@
 import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { ExecutorAccountDetails } from "../../../types";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
 
 export class HederaCreateFungibleTokenTool extends Tool {
     name = 'hedera_create_fungible_token';
@@ -25,20 +24,12 @@ tokenMetadata: string, containing metadata associated with this token, empty str
 
     protected override async _call(input: any, _runManager?: CallbackManagerForToolRun, config?: ToolRunnableConfig): Promise<string> {
         try {
-           const isCustodial = config?.configurable?.isCustodial === true;
-           const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-          if (!isCustodial && !executorAccountDetails) {
-            throw new Error("Executor account details are required for non-custodial mode.");
-          }
-
-          if (executorAccountDetails) {
-            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+            const isCustodial = config?.configurable?.isCustodial === true;
+            const executorAccountDetails = await prepareExecutorAccountDetails(
               isCustodial,
-              executorAccountDetails,
+              config?.configurable?.executorAccountDetails,
               this.hederaKit.network
             );
-          }
 
            console.log(`hedera_create_fungible_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/create_fungible_token_tool.ts
+++ b/src/langchain/tools/hts/create_fungible_token_tool.ts
@@ -28,11 +28,17 @@ tokenMetadata: string, containing metadata associated with this token, empty str
            const isCustodial = config?.configurable?.isCustodial === true;
            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-          executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-            isCustodial,
-            executorAccountDetails,
-            this.hederaKit.network
-          );
+          if (!isCustodial && !executorAccountDetails) {
+            throw new Error("Executor account details are required for non-custodial mode.");
+          }
+
+          if (executorAccountDetails) {
+            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+              isCustodial,
+              executorAccountDetails,
+              this.hederaKit.network
+            );
+          }
 
            console.log(`hedera_create_fungible_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/create_non_fungible_token_tool.ts
+++ b/src/langchain/tools/hts/create_non_fungible_token_tool.ts
@@ -2,7 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
-import { getPublicKeyByAccountId } from "../../../utils/api-utils";
+import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
 
 // FIXME: works well in isolation but normally usually createFT is called instead of createNFT
 export class HederaCreateNonFungibleTokenTool extends Tool {
@@ -29,15 +29,11 @@ Inputs (input is a JSON string):
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-                if (!executorAccountDetails.executorAccountId)
-                    throw new Error("Executor account ID is required for non-custodial mode");
-
-                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
-                  this.hederaKit.network,
-                  executorAccountDetails.executorAccountId
-                );
-            }
+            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+              isCustodial,
+              executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_create_non_fungible_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/create_non_fungible_token_tool.ts
+++ b/src/langchain/tools/hts/create_non_fungible_token_tool.ts
@@ -29,11 +29,17 @@ Inputs (input is a JSON string):
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-              isCustodial,
-              executorAccountDetails,
-              this.hederaKit.network
-            );
+            if (!isCustodial && !executorAccountDetails) {
+                throw new Error("Executor account details are required for non-custodial mode.");
+            }
+
+            if (executorAccountDetails) {
+                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+                  isCustodial,
+                  executorAccountDetails,
+                  this.hederaKit.network
+                );
+            }
 
             console.log(`hedera_create_non_fungible_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/create_non_fungible_token_tool.ts
+++ b/src/langchain/tools/hts/create_non_fungible_token_tool.ts
@@ -2,6 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 // FIXME: works well in isolation but normally usually createFT is called instead of createNFT
 export class HederaCreateNonFungibleTokenTool extends Tool {
@@ -27,6 +28,16 @@ Inputs (input is a JSON string):
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+                if (!executorAccountDetails.executorAccountId)
+                    throw new Error("Executor account ID is required for non-custodial mode");
+
+                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+                  this.hederaKit.network,
+                  executorAccountDetails.executorAccountId
+                );
+            }
 
             console.log(`hedera_create_non_fungible_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/create_non_fungible_token_tool.ts
+++ b/src/langchain/tools/hts/create_non_fungible_token_tool.ts
@@ -1,8 +1,8 @@
 import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { ExecutorAccountDetails } from "../../../types";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
+
 
 // FIXME: works well in isolation but normally usually createFT is called instead of createNFT
 export class HederaCreateNonFungibleTokenTool extends Tool {
@@ -27,19 +27,11 @@ Inputs (input is a JSON string):
     protected override async _call(input: any, _runManager?: CallbackManagerForToolRun, config?: ToolRunnableConfig): Promise<string> {
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
-            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-            if (!isCustodial && !executorAccountDetails) {
-                throw new Error("Executor account details are required for non-custodial mode.");
-            }
-
-            if (executorAccountDetails) {
-                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-                  isCustodial,
-                  executorAccountDetails,
-                  this.hederaKit.network
-                );
-            }
+            const executorAccountDetails = await prepareExecutorAccountDetails(
+              isCustodial,
+              config?.configurable?.executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_create_non_fungible_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/dissociate_token_tool.ts
+++ b/src/langchain/tools/hts/dissociate_token_tool.ts
@@ -26,11 +26,17 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-              isCustodial,
-              executorAccountDetails,
-              this.hederaKit.network
-            );
+            if (!isCustodial && !executorAccountDetails) {
+                throw new Error("Executor account details are required for non-custodial mode.");
+            }
+
+            if (executorAccountDetails) {
+                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+                  isCustodial,
+                  executorAccountDetails,
+                  this.hederaKit.network
+                );
+            }
 
             console.log(`hedera_dissociate_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/dissociate_token_tool.ts
+++ b/src/langchain/tools/hts/dissociate_token_tool.ts
@@ -1,8 +1,7 @@
 import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { ExecutorAccountDetails } from "../../../types";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
 
 export class HederaDissociateTokenTool extends Tool {
     name = 'hedera_dissociate_token';
@@ -24,19 +23,11 @@ Example usage:
     protected override async _call(input: any, _runManager?: CallbackManagerForToolRun, config?: ToolRunnableConfig): Promise<string> {
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
-            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-            if (!isCustodial && !executorAccountDetails) {
-                throw new Error("Executor account details are required for non-custodial mode.");
-            }
-
-            if (executorAccountDetails) {
-                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-                  isCustodial,
-                  executorAccountDetails,
-                  this.hederaKit.network
-                );
-            }
+            const executorAccountDetails = await prepareExecutorAccountDetails(
+              isCustodial,
+              config?.configurable?.executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_dissociate_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/dissociate_token_tool.ts
+++ b/src/langchain/tools/hts/dissociate_token_tool.ts
@@ -2,6 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 export class HederaDissociateTokenTool extends Tool {
     name = 'hedera_dissociate_token';
@@ -24,6 +25,16 @@ Example usage:
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+                if (!executorAccountDetails.executorAccountId)
+                    throw new Error("Executor account ID is required for non-custodial mode");
+
+                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+                  this.hederaKit.network,
+                  executorAccountDetails.executorAccountId
+                );
+            }
 
             console.log(`hedera_dissociate_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/dissociate_token_tool.ts
+++ b/src/langchain/tools/hts/dissociate_token_tool.ts
@@ -2,7 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
-import { getPublicKeyByAccountId } from "../../../utils/api-utils";
+import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
 
 export class HederaDissociateTokenTool extends Tool {
     name = 'hedera_dissociate_token';
@@ -26,15 +26,11 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-                if (!executorAccountDetails.executorAccountId)
-                    throw new Error("Executor account ID is required for non-custodial mode");
-
-                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
-                  this.hederaKit.network,
-                  executorAccountDetails.executorAccountId
-                );
-            }
+            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+              isCustodial,
+              executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_dissociate_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/get_all_token_balances_tool.ts
+++ b/src/langchain/tools/hts/get_all_token_balances_tool.ts
@@ -1,8 +1,8 @@
 import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
-import { ExecutorAccountDetails, HederaNetworkType } from "../../../types";
+import { HederaNetworkType } from "../../../types";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
 
 export class HederaGetAllTokenBalancesTool extends Tool {
     name = 'hedera_get_all_token_balances'
@@ -29,19 +29,11 @@ Example usage:
     protected override async _call(input: any, _runManager?: CallbackManagerForToolRun, config?: ToolRunnableConfig): Promise<string> {
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
-            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-            if (!isCustodial && !executorAccountDetails) {
-                throw new Error("Executor account details are required for non-custodial mode.");
-            }
-
-            if (executorAccountDetails) {
-                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-                  isCustodial,
-                  executorAccountDetails,
-                  this.hederaKit.network
-                );
-            }
+            const executorAccountDetails = await prepareExecutorAccountDetails(
+              isCustodial,
+              config?.configurable?.executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_get_all_token_balances tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/get_all_token_balances_tool.ts
+++ b/src/langchain/tools/hts/get_all_token_balances_tool.ts
@@ -2,6 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { ExecutorAccountDetails, HederaNetworkType } from "../../../types";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 export class HederaGetAllTokenBalancesTool extends Tool {
     name = 'hedera_get_all_token_balances'
@@ -29,6 +30,16 @@ Example usage:
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+                if (!executorAccountDetails.executorAccountId)
+                    throw new Error("Executor account ID is required for non-custodial mode");
+
+                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+                  this.hederaKit.network,
+                  executorAccountDetails.executorAccountId
+                );
+            }
 
             console.log(`hedera_get_all_token_balances tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/get_all_token_balances_tool.ts
+++ b/src/langchain/tools/hts/get_all_token_balances_tool.ts
@@ -31,11 +31,17 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-              isCustodial,
-              executorAccountDetails,
-              this.hederaKit.network
-            );
+            if (!isCustodial && !executorAccountDetails) {
+                throw new Error("Executor account details are required for non-custodial mode.");
+            }
+
+            if (executorAccountDetails) {
+                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+                  isCustodial,
+                  executorAccountDetails,
+                  this.hederaKit.network
+                );
+            }
 
             console.log(`hedera_get_all_token_balances tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/get_all_token_balances_tool.ts
+++ b/src/langchain/tools/hts/get_all_token_balances_tool.ts
@@ -2,7 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { ExecutorAccountDetails, HederaNetworkType } from "../../../types";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { getPublicKeyByAccountId } from "../../../utils/api-utils";
+import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
 
 export class HederaGetAllTokenBalancesTool extends Tool {
     name = 'hedera_get_all_token_balances'
@@ -31,15 +31,11 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-                if (!executorAccountDetails.executorAccountId)
-                    throw new Error("Executor account ID is required for non-custodial mode");
-
-                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
-                  this.hederaKit.network,
-                  executorAccountDetails.executorAccountId
-                );
-            }
+            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+              isCustodial,
+              executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_get_all_token_balances tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/get_hts_balance_tool.ts
+++ b/src/langchain/tools/hts/get_hts_balance_tool.ts
@@ -34,11 +34,17 @@ If no account ID is given, it returns the balance for the connected account.
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-              isCustodial,
-              executorAccountDetails,
-              this.hederaKit.network
-            );
+            if (!isCustodial && !executorAccountDetails) {
+                throw new Error("Executor account details are required for non-custodial mode.");
+            }
+
+            if (executorAccountDetails) {
+                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+                  isCustodial,
+                  executorAccountDetails,
+                  this.hederaKit.network
+                );
+            }
 
             console.log('hedera_get_hts_balance tool has been called')
 

--- a/src/langchain/tools/hts/get_hts_balance_tool.ts
+++ b/src/langchain/tools/hts/get_hts_balance_tool.ts
@@ -3,6 +3,7 @@ import HederaAgentKit from "../../../agent";
 import { ExecutorAccountDetails, HederaNetworkType } from "../../../types";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { toDisplayUnit } from "../../../utils/hts-format-utils";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 export class HederaGetHtsBalanceTool extends Tool {
     name = 'hedera_get_hts_balance'
@@ -32,6 +33,16 @@ If no account ID is given, it returns the balance for the connected account.
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+                if (!executorAccountDetails.executorAccountId)
+                    throw new Error("Executor account ID is required for non-custodial mode");
+
+                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+                  this.hederaKit.network,
+                  executorAccountDetails.executorAccountId
+                );
+            }
 
             console.log('hedera_get_hts_balance tool has been called')
 

--- a/src/langchain/tools/hts/get_hts_balance_tool.ts
+++ b/src/langchain/tools/hts/get_hts_balance_tool.ts
@@ -1,9 +1,9 @@
 import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
-import { ExecutorAccountDetails, HederaNetworkType } from "../../../types";
+import { HederaNetworkType } from "../../../types";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { toDisplayUnit } from "../../../utils/hts-format-utils";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
 
 export class HederaGetHtsBalanceTool extends Tool {
     name = 'hedera_get_hts_balance'
@@ -32,19 +32,11 @@ If no account ID is given, it returns the balance for the connected account.
     protected override async _call(input: any, _runManager?: CallbackManagerForToolRun, config?: ToolRunnableConfig): Promise<string> {
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
-            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-            if (!isCustodial && !executorAccountDetails) {
-                throw new Error("Executor account details are required for non-custodial mode.");
-            }
-
-            if (executorAccountDetails) {
-                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-                  isCustodial,
-                  executorAccountDetails,
-                  this.hederaKit.network
-                );
-            }
+            const executorAccountDetails = await prepareExecutorAccountDetails(
+              isCustodial,
+              config?.configurable?.executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log('hedera_get_hts_balance tool has been called')
 

--- a/src/langchain/tools/hts/get_hts_balance_tool.ts
+++ b/src/langchain/tools/hts/get_hts_balance_tool.ts
@@ -3,7 +3,7 @@ import HederaAgentKit from "../../../agent";
 import { ExecutorAccountDetails, HederaNetworkType } from "../../../types";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { toDisplayUnit } from "../../../utils/hts-format-utils";
-import { getPublicKeyByAccountId } from "../../../utils/api-utils";
+import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
 
 export class HederaGetHtsBalanceTool extends Tool {
     name = 'hedera_get_hts_balance'
@@ -34,15 +34,11 @@ If no account ID is given, it returns the balance for the connected account.
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-                if (!executorAccountDetails.executorAccountId)
-                    throw new Error("Executor account ID is required for non-custodial mode");
-
-                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
-                  this.hederaKit.network,
-                  executorAccountDetails.executorAccountId
-                );
-            }
+            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+              isCustodial,
+              executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log('hedera_get_hts_balance tool has been called')
 

--- a/src/langchain/tools/hts/get_pending_airdrop_tool.ts
+++ b/src/langchain/tools/hts/get_pending_airdrop_tool.ts
@@ -1,8 +1,8 @@
 import { Tool, ToolRunnableConfig, } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
-import { ExecutorAccountDetails, HederaNetworkType } from "../../../types";
+import { HederaNetworkType } from "../../../types";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
 
 export class HederaGetPendingAirdropTool extends Tool {
     name = 'hedera_get_pending_airdrop'
@@ -26,19 +26,11 @@ Example usage:
     protected override async _call(input: any, _runManager?: CallbackManagerForToolRun, config?: ToolRunnableConfig): Promise<string> {
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
-            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-            if (!isCustodial && !executorAccountDetails) {
-                throw new Error("Executor account details are required for non-custodial mode.");
-            }
-
-            if (executorAccountDetails) {
-                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-                  isCustodial,
-                  executorAccountDetails,
-                  this.hederaKit.network
-                );
-            }
+            const executorAccountDetails = await prepareExecutorAccountDetails(
+              isCustodial,
+              config?.configurable?.executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_get_pending_airdrop tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/get_pending_airdrop_tool.ts
+++ b/src/langchain/tools/hts/get_pending_airdrop_tool.ts
@@ -28,11 +28,17 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-              isCustodial,
-              executorAccountDetails,
-              this.hederaKit.network
-            );
+            if (!isCustodial && !executorAccountDetails) {
+                throw new Error("Executor account details are required for non-custodial mode.");
+            }
+
+            if (executorAccountDetails) {
+                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+                  isCustodial,
+                  executorAccountDetails,
+                  this.hederaKit.network
+                );
+            }
 
             console.log(`hedera_get_pending_airdrop tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/get_pending_airdrop_tool.ts
+++ b/src/langchain/tools/hts/get_pending_airdrop_tool.ts
@@ -2,7 +2,7 @@ import { Tool, ToolRunnableConfig, } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { ExecutorAccountDetails, HederaNetworkType } from "../../../types";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { getPublicKeyByAccountId } from "../../../utils/api-utils";
+import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
 
 export class HederaGetPendingAirdropTool extends Tool {
     name = 'hedera_get_pending_airdrop'
@@ -28,15 +28,11 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-                if (!executorAccountDetails.executorAccountId)
-                    throw new Error("Executor account ID is required for non-custodial mode");
-
-                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
-                  this.hederaKit.network,
-                  executorAccountDetails.executorAccountId
-                );
-            }
+            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+              isCustodial,
+              executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_get_pending_airdrop tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/get_pending_airdrop_tool.ts
+++ b/src/langchain/tools/hts/get_pending_airdrop_tool.ts
@@ -2,6 +2,7 @@ import { Tool, ToolRunnableConfig, } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { ExecutorAccountDetails, HederaNetworkType } from "../../../types";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 export class HederaGetPendingAirdropTool extends Tool {
     name = 'hedera_get_pending_airdrop'
@@ -26,6 +27,16 @@ Example usage:
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+                if (!executorAccountDetails.executorAccountId)
+                    throw new Error("Executor account ID is required for non-custodial mode");
+
+                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+                  this.hederaKit.network,
+                  executorAccountDetails.executorAccountId
+                );
+            }
 
             console.log(`hedera_get_pending_airdrop tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/mint_fungible_token_tool.ts
+++ b/src/langchain/tools/hts/mint_fungible_token_tool.ts
@@ -1,9 +1,9 @@
 import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { ExecutorAccountDetails, HederaNetworkType } from "../../../types";
+import { HederaNetworkType } from "../../../types";
 import { toBaseUnit } from "../../../utils/hts-format-utils";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
 
 export class HederaMintFungibleTokenTool extends Tool {
     name = 'hedera_mint_fungible_token';
@@ -27,19 +27,11 @@ Example usage:
     protected override async _call(input: any, _runManager?: CallbackManagerForToolRun, config?: ToolRunnableConfig): Promise<string> {
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
-            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-            if (!isCustodial && !executorAccountDetails) {
-                throw new Error("Executor account details are required for non-custodial mode.");
-            }
-
-            if (executorAccountDetails) {
-                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-                  isCustodial,
-                  executorAccountDetails,
-                  this.hederaKit.network
-                );
-            }
+            const executorAccountDetails = await prepareExecutorAccountDetails(
+              isCustodial,
+              config?.configurable?.executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_mint_fungible_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/mint_fungible_token_tool.ts
+++ b/src/langchain/tools/hts/mint_fungible_token_tool.ts
@@ -3,7 +3,7 @@ import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails, HederaNetworkType } from "../../../types";
 import { toBaseUnit } from "../../../utils/hts-format-utils";
-import { getPublicKeyByAccountId } from "../../../utils/api-utils";
+import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
 
 export class HederaMintFungibleTokenTool extends Tool {
     name = 'hedera_mint_fungible_token';
@@ -29,15 +29,11 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-                if (!executorAccountDetails.executorAccountId)
-                    throw new Error("Executor account ID is required for non-custodial mode");
-
-                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
-                  this.hederaKit.network,
-                  executorAccountDetails.executorAccountId
-                );
-            }
+            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+              isCustodial,
+              executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_mint_fungible_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/mint_fungible_token_tool.ts
+++ b/src/langchain/tools/hts/mint_fungible_token_tool.ts
@@ -3,6 +3,7 @@ import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails, HederaNetworkType } from "../../../types";
 import { toBaseUnit } from "../../../utils/hts-format-utils";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 export class HederaMintFungibleTokenTool extends Tool {
     name = 'hedera_mint_fungible_token';
@@ -27,6 +28,16 @@ Example usage:
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+                if (!executorAccountDetails.executorAccountId)
+                    throw new Error("Executor account ID is required for non-custodial mode");
+
+                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+                  this.hederaKit.network,
+                  executorAccountDetails.executorAccountId
+                );
+            }
 
             console.log(`hedera_mint_fungible_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/mint_fungible_token_tool.ts
+++ b/src/langchain/tools/hts/mint_fungible_token_tool.ts
@@ -29,11 +29,17 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-              isCustodial,
-              executorAccountDetails,
-              this.hederaKit.network
-            );
+            if (!isCustodial && !executorAccountDetails) {
+                throw new Error("Executor account details are required for non-custodial mode.");
+            }
+
+            if (executorAccountDetails) {
+                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+                  isCustodial,
+                  executorAccountDetails,
+                  this.hederaKit.network
+                );
+            }
 
             console.log(`hedera_mint_fungible_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/mint_non_fungible_token_tool.ts
+++ b/src/langchain/tools/hts/mint_non_fungible_token_tool.ts
@@ -28,11 +28,17 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-              isCustodial,
-              executorAccountDetails,
-              this.hederaKit.network
-            );
+            if (!isCustodial && !executorAccountDetails) {
+                throw new Error("Executor account details are required for non-custodial mode.");
+            }
+
+            if (executorAccountDetails) {
+                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+                  isCustodial,
+                  executorAccountDetails,
+                  this.hederaKit.network
+                );
+            }
 
             console.log(`hedera_mint_nft tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/mint_non_fungible_token_tool.ts
+++ b/src/langchain/tools/hts/mint_non_fungible_token_tool.ts
@@ -2,6 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 export class HederaMintNFTTool extends Tool {
     name = 'hedera_mint_nft';
@@ -26,6 +27,16 @@ Example usage:
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+                if (!executorAccountDetails.executorAccountId)
+                    throw new Error("Executor account ID is required for non-custodial mode");
+
+                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+                  this.hederaKit.network,
+                  executorAccountDetails.executorAccountId
+                );
+            }
 
             console.log(`hedera_mint_nft tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/mint_non_fungible_token_tool.ts
+++ b/src/langchain/tools/hts/mint_non_fungible_token_tool.ts
@@ -1,8 +1,7 @@
 import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { ExecutorAccountDetails } from "../../../types";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
 
 export class HederaMintNFTTool extends Tool {
     name = 'hedera_mint_nft';
@@ -26,19 +25,11 @@ Example usage:
     protected override async _call(input: any, _runManager?: CallbackManagerForToolRun, config?: ToolRunnableConfig): Promise<string> {
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
-            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-            if (!isCustodial && !executorAccountDetails) {
-                throw new Error("Executor account details are required for non-custodial mode.");
-            }
-
-            if (executorAccountDetails) {
-                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-                  isCustodial,
-                  executorAccountDetails,
-                  this.hederaKit.network
-                );
-            }
+            const executorAccountDetails = await prepareExecutorAccountDetails(
+              isCustodial,
+              config?.configurable?.executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_mint_nft tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/mint_non_fungible_token_tool.ts
+++ b/src/langchain/tools/hts/mint_non_fungible_token_tool.ts
@@ -2,7 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
-import { getPublicKeyByAccountId } from "../../../utils/api-utils";
+import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
 
 export class HederaMintNFTTool extends Tool {
     name = 'hedera_mint_nft';
@@ -28,15 +28,11 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-                if (!executorAccountDetails.executorAccountId)
-                    throw new Error("Executor account ID is required for non-custodial mode");
-
-                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
-                  this.hederaKit.network,
-                  executorAccountDetails.executorAccountId
-                );
-            }
+            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+              isCustodial,
+              executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_mint_nft tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/reject_token_tool.ts
+++ b/src/langchain/tools/hts/reject_token_tool.ts
@@ -2,8 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { TokenId } from "@hashgraph/sdk";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { ExecutorAccountDetails } from "../../../types";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
 
 export class HederaRejectTokenTool extends Tool {
     name = 'hedera_reject_token';
@@ -25,19 +24,11 @@ Example usage:
     protected override async _call(input: any, _runManager?: CallbackManagerForToolRun, config?: ToolRunnableConfig): Promise<string> {
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
-            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-            if (!isCustodial && !executorAccountDetails) {
-                throw new Error("Executor account details are required for non-custodial mode.");
-            }
-
-            if (executorAccountDetails) {
-                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-                  isCustodial,
-                  executorAccountDetails,
-                  this.hederaKit.network
-                );
-            }
+            const executorAccountDetails = await prepareExecutorAccountDetails(
+              isCustodial,
+              config?.configurable?.executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_reject_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/reject_token_tool.ts
+++ b/src/langchain/tools/hts/reject_token_tool.ts
@@ -3,6 +3,7 @@ import HederaAgentKit from "../../../agent";
 import { TokenId } from "@hashgraph/sdk";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 export class HederaRejectTokenTool extends Tool {
     name = 'hedera_reject_token';
@@ -25,6 +26,16 @@ Example usage:
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+                if (!executorAccountDetails.executorAccountId)
+                    throw new Error("Executor account ID is required for non-custodial mode");
+
+                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+                  this.hederaKit.network,
+                  executorAccountDetails.executorAccountId
+                );
+            }
 
             console.log(`hedera_reject_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/reject_token_tool.ts
+++ b/src/langchain/tools/hts/reject_token_tool.ts
@@ -3,7 +3,7 @@ import HederaAgentKit from "../../../agent";
 import { TokenId } from "@hashgraph/sdk";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
-import { getPublicKeyByAccountId } from "../../../utils/api-utils";
+import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
 
 export class HederaRejectTokenTool extends Tool {
     name = 'hedera_reject_token';
@@ -27,15 +27,11 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-                if (!executorAccountDetails.executorAccountId)
-                    throw new Error("Executor account ID is required for non-custodial mode");
-
-                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
-                  this.hederaKit.network,
-                  executorAccountDetails.executorAccountId
-                );
-            }
+            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+              isCustodial,
+              executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_reject_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/reject_token_tool.ts
+++ b/src/langchain/tools/hts/reject_token_tool.ts
@@ -27,11 +27,17 @@ Example usage:
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-              isCustodial,
-              executorAccountDetails,
-              this.hederaKit.network
-            );
+            if (!isCustodial && !executorAccountDetails) {
+                throw new Error("Executor account details are required for non-custodial mode.");
+            }
+
+            if (executorAccountDetails) {
+                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+                  isCustodial,
+                  executorAccountDetails,
+                  this.hederaKit.network
+                );
+            }
 
             console.log(`hedera_reject_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/transfer_token_tool.ts
+++ b/src/langchain/tools/hts/transfer_token_tool.ts
@@ -24,11 +24,17 @@ amount: number, the amount of tokens to transfer e.g. 100 in base unit
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-              isCustodial,
-              executorAccountDetails,
-              this.hederaKit.network
-            );
+            if (!isCustodial && !executorAccountDetails) {
+                throw new Error("Executor account details are required for non-custodial mode.");
+            }
+
+            if (executorAccountDetails) {
+                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+                  isCustodial,
+                  executorAccountDetails,
+                  this.hederaKit.network
+                );
+            }
 
             console.log(`hedera_transfer_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/transfer_token_tool.ts
+++ b/src/langchain/tools/hts/transfer_token_tool.ts
@@ -2,8 +2,7 @@ import { Tool, ToolRunnableConfig } from "@langchain/core/tools";
 import HederaAgentKit from "../../../agent";
 import { toBaseUnit } from "../../../utils/hts-format-utils";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { ExecutorAccountDetails } from "../../../types";
-import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
+import { prepareExecutorAccountDetails } from "../../../utils/langchain-tools-utils";
 
 export class HederaTransferTokenTool extends Tool {
     name = 'hedera_transfer_token';
@@ -22,19 +21,11 @@ amount: number, the amount of tokens to transfer e.g. 100 in base unit
     protected override async _call(input: any, _runManager?: CallbackManagerForToolRun, config?: ToolRunnableConfig): Promise<string> {
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
-            const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
-
-            if (!isCustodial && !executorAccountDetails) {
-                throw new Error("Executor account details are required for non-custodial mode.");
-            }
-
-            if (executorAccountDetails) {
-                executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
-                  isCustodial,
-                  executorAccountDetails,
-                  this.hederaKit.network
-                );
-            }
+            const executorAccountDetails = await prepareExecutorAccountDetails(
+              isCustodial,
+              config?.configurable?.executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_transfer_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/transfer_token_tool.ts
+++ b/src/langchain/tools/hts/transfer_token_tool.ts
@@ -3,7 +3,7 @@ import HederaAgentKit from "../../../agent";
 import { toBaseUnit } from "../../../utils/hts-format-utils";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
-import { getPublicKeyByAccountId } from "../../../utils/api-utils";
+import { optionalFetchPublicKey } from "../../../utils/langchain-tools-utils";
 
 export class HederaTransferTokenTool extends Tool {
     name = 'hedera_transfer_token';
@@ -24,15 +24,11 @@ amount: number, the amount of tokens to transfer e.g. 100 in base unit
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
 
-            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-                if (!executorAccountDetails.executorAccountId)
-                    throw new Error("Executor account ID is required for non-custodial mode");
-
-                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
-                  this.hederaKit.network,
-                  executorAccountDetails.executorAccountId
-                );
-            }
+            executorAccountDetails.executorPublicKey = await optionalFetchPublicKey(
+              isCustodial,
+              executorAccountDetails,
+              this.hederaKit.network
+            );
 
             console.log(`hedera_transfer_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/langchain/tools/hts/transfer_token_tool.ts
+++ b/src/langchain/tools/hts/transfer_token_tool.ts
@@ -3,6 +3,7 @@ import HederaAgentKit from "../../../agent";
 import { toBaseUnit } from "../../../utils/hts-format-utils";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ExecutorAccountDetails } from "../../../types";
+import { getPublicKeyByAccountId } from "../../../utils/api-utils";
 
 export class HederaTransferTokenTool extends Tool {
     name = 'hedera_transfer_token';
@@ -22,6 +23,16 @@ amount: number, the amount of tokens to transfer e.g. 100 in base unit
         try {
             const isCustodial = config?.configurable?.isCustodial === true;
             const executorAccountDetails: ExecutorAccountDetails = config?.configurable?.executorAccountDetails;
+
+            if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+                if (!executorAccountDetails.executorAccountId)
+                    throw new Error("Executor account ID is required for non-custodial mode");
+
+                executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
+                  this.hederaKit.network,
+                  executorAccountDetails.executorAccountId
+                );
+            }
 
             console.log(`hedera_transfer_token tool has been called (${isCustodial ? 'custodial' : 'non-custodial'})`);
 

--- a/src/utils/api-utils.ts
+++ b/src/utils/api-utils.ts
@@ -4,3 +4,10 @@ export const createBaseMirrorNodeApiUrl = (networkType: HederaNetworkType) => {
     const networkBase = networkType === 'mainnet' ? `${networkType}-public` : networkType;
     return `https://${networkBase}.mirrornode.hedera.com`
 }
+
+export const getPublicKeyByAccountId = async (networkType: HederaNetworkType, accountId: string): Promise<string> => {
+    const baseUrl = createBaseMirrorNodeApiUrl(networkType);
+    const url = `${baseUrl}/api/v1/accounts/${accountId}?limit=1&transactions=true`;
+    const response = await fetch(url).then(response => response.json());
+    return response.key.key;
+}

--- a/src/utils/langchain-tools-utils.ts
+++ b/src/utils/langchain-tools-utils.ts
@@ -1,0 +1,19 @@
+import { ExecutorAccountDetails, HederaNetworkType } from "../types"
+import { getPublicKeyByAccountId } from "./api-utils";
+
+export const optionalFetchPublicKey = (
+  isCustodial: boolean,
+  executorAccountDetails: ExecutorAccountDetails,
+  hederaNetworkType: HederaNetworkType
+): Promise<string | undefined> => {
+  if (!isCustodial && !executorAccountDetails.executorPublicKey) {
+    if (!executorAccountDetails.executorAccountId)
+      throw new Error("Executor account ID is required for non-custodial mode");
+
+    return getPublicKeyByAccountId(
+      hederaNetworkType,
+      executorAccountDetails.executorAccountId
+    );
+  }
+  return Promise.resolve(executorAccountDetails.executorPublicKey);
+}

--- a/src/utils/langchain-tools-utils.ts
+++ b/src/utils/langchain-tools-utils.ts
@@ -1,19 +1,34 @@
-import { ExecutorAccountDetails, HederaNetworkType } from "../types"
+import { ExecutorAccountDetails, HederaNetworkType } from "../types";
 import { getPublicKeyByAccountId } from "./api-utils";
 
-export const optionalFetchPublicKey = (
+/**
+ * Ensures executor account details are correctly prepared when using non-custodial mode.
+ * If needed, fetches and sets an executor public key.
+ */
+export const prepareExecutorAccountDetails = async (
   isCustodial: boolean,
-  executorAccountDetails: ExecutorAccountDetails,
+  executorAccountDetails: ExecutorAccountDetails | undefined,
   hederaNetworkType: HederaNetworkType
-): Promise<string | undefined> => {
-  if (!isCustodial && !executorAccountDetails.executorPublicKey) {
-    if (!executorAccountDetails.executorAccountId)
-      throw new Error("Executor account ID is required for non-custodial mode");
+): Promise<ExecutorAccountDetails | undefined> => {
+  if (isCustodial) {
+    return executorAccountDetails;
+  }
 
-    return getPublicKeyByAccountId(
+  if (!executorAccountDetails) {
+    throw new Error("Executor account details are required for non-custodial mode.");
+  }
+
+  if (!executorAccountDetails.executorAccountId) {
+    throw new Error("Executor account ID is required for non-custodial mode.");
+  }
+
+  if (!executorAccountDetails.executorPublicKey) {
+    executorAccountDetails.executorPublicKey = await getPublicKeyByAccountId(
       hederaNetworkType,
       executorAccountDetails.executorAccountId
     );
   }
-  return Promise.resolve(executorAccountDetails.executorPublicKey);
-}
+
+  return executorAccountDetails;
+};
+


### PR DESCRIPTION
implements additional check if the public key was passed along the non-custodial action call. If not it is fetched based on the account id.

This has to be done separately inside each tool because the mcp server uses just the tools, and the tools are first place in HederaAgentKit library where we can check if the public key was provided.

Also this piece of code can be excluded to some utils function but it needs multiple parameters and might not result in shorter or clearer implementation in each tool.
