### PR TITLE
feat: modify responses to non-custodial action to acknowledge that th…

### DIFF
--- a/src/tests/utils/utils.ts
+++ b/src/tests/utils/utils.ts
@@ -60,6 +60,7 @@ export async function initializeAgent() {
       checkpointSaver: memory,
       // You can adjust this message for your scenario:
       messageModifier: `
+        **General Guidelines**:
         You are a helpful agent that can interact on-chain using the Hedera Agent Kit. 
         You are empowered to interact on-chain using your tools. If you ever need funds,
         you can request them from a faucet or from the user. 
@@ -67,7 +68,16 @@ export async function initializeAgent() {
         If someone asks you to do something you can't do with your available tools, you 
         must say so, and encourage them to implement it themselves with the Hedera Agent Kit. 
         Keep your responses concise and helpful.
-      `,
+        
+        **Non-custodial Flow Guidelines**:
+        When action returns 'txBytes', it is not successfully executed yet, so its goal is not complete.
+        In such case, emphasize to the user that the transaction bytes have been created successfully.
+        Let the user know that now he has to sign them in order to execute the prepared transaction
+        
+        **Token Creation Rules**:
+        If the user mentions **NFT**, **non-fungible token**, or **unique token**, always use the **hedera_create_non_fungible_token** tool.
+        If the user mentions **fungible token**, **FT**, or **decimal-based token**, always use the **hedera_create_fungible_token** tool.
+       `,
     });
 
     return { agent, config };

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -63,7 +63,7 @@ async function initializeAgent() {
       checkpointSaver: memory,
       // You can adjust this message for your scenario:
       messageModifier: `
-        **General Guidelines**
+        **General Guidelines**:
         You are a helpful agent that can interact on-chain using the Hedera Agent Kit. 
         You are empowered to interact on-chain using your tools. If you ever need funds,
         you can request them from a faucet or from the user. 
@@ -72,10 +72,14 @@ async function initializeAgent() {
         must say so, and encourage them to implement it themselves with the Hedera Agent Kit. 
         Keep your responses concise and helpful.
         
+        **Non-custodial Flow Guidelines**:
+        When action returns 'txBytes', it is not successfully executed yet, so its goal is not complete.
+        In such case, emphasize to the user that the transaction bytes have been created successfully.
+        Let the user know that now he has to sign them in order to execute the prepared transaction
+        
         **Token Creation Rules**:
         If the user mentions **NFT**, **non-fungible token**, or **unique token**, always use the **hedera_create_non_fungible_token** tool.
         If the user mentions **fungible token**, **FT**, or **decimal-based token**, always use the **hedera_create_fungible_token** tool.
-        
       `,
     });
 


### PR DESCRIPTION
Instead of implementing new status, the langchain agent config now defines how it should act when `txBytes` are returned.

This approach requires no refactor of action and works fine