### PR TITLE
fix: fix create fungible token memo setting (CSS-202)

### DIFF
--- a/src/langchain/tools/hts/create_fungible_token_tool.ts
+++ b/src/langchain/tools/hts/create_fungible_token_tool.ts
@@ -15,7 +15,7 @@ initialSupply: number, optional, the initial supply of the token, given in displ
 isSupplyKey: boolean, decides whether supply key should be set, false if not passed
 isMetadataKey: boolean, decides whether metadata key should be set, false if not passed
 isAdminKey: boolean, decides whether admin key should be set, false if not passed
-memo: string, containing memo associated with this token, empty string if not passed
+memo: string, containing token's memo. Do not create it yourself if not passed but set it to empty string. Do not set it to token name.
 tokenMetadata: string, containing metadata associated with this token, empty string if not passed`;
 
     constructor(private hederaKit: HederaAgentKit) {

--- a/src/tests/custodial/create_fungible_token.test.ts
+++ b/src/tests/custodial/create_fungible_token.test.ts
@@ -203,7 +203,6 @@ describe("create_fungible_token", () => {
     expect(tokenDetails.decimals).toEqual("1");
     expect(Number(tokenDetails.initial_supply) / Math.pow(10, Number(tokenDetails.decimals))).toEqual(111);
     expect(tokenDetails.memo).toBe("");
-    expect(tokenDetails.memo).toBe("");
     expect(tokenDetails?.supply_key?.key).not.toBeUndefined();
     expect(tokenDetails?.admin_key?.key).not.toBeUndefined();
     expect(tokenDetails?.metadata_key?.key).toBeUndefined();


### PR DESCRIPTION
fixes error with LLM creating some memo for fungible tokens out of message context if no memo was passed.