### PR TITLE
Ccs 188 add test coverage for non custodial actions pt2

### DIFF
--- a/src/langchain/tools/hts/claim_airdrop_tool.ts
+++ b/src/langchain/tools/hts/claim_airdrop_tool.ts
@@ -38,7 +38,7 @@ Example usage:
             const airdropId = new PendingAirdropId({
                 tokenId: TokenId.fromString(parsedInput.tokenId),
                 senderId: AccountId.fromString(parsedInput.senderAccountId),
-                receiverId: this.hederaKit.client.operatorAccountId!
+                receiverId: isCustodial ? this.hederaKit.client.operatorAccountId! : AccountId.fromString(executorAccountDetails?.executorAccountId!)
             });
 
             return await this.hederaKit

--- a/src/tests/custodial/create_nft_token.test.ts
+++ b/src/tests/custodial/create_nft_token.test.ts
@@ -5,10 +5,9 @@ import * as dotenv from "dotenv";
 import { LangchainAgent } from "../utils/langchainAgent";
 import { NetworkClientWrapper } from "../utils/testnetClient";
 import {TokenType} from "@hashgraph/sdk";
+import { wait } from "../utils/utils";
 
 const IS_CUSTODIAL = true;
-
-const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function extractTokenId(messages: any[]): string {
     const result = messages.reduce<string | null>((acc, message) => {
@@ -45,8 +44,7 @@ describe("create_nft_token", () => {
         );
         hederaApiClient = new HederaMirrorNodeClient("testnet" as NetworkType);
 
-        }
-    );
+    });
 
     beforeEach(async () => {
         dotenv.config();

--- a/src/tests/custodial/dissociate_token.test.ts
+++ b/src/tests/custodial/dissociate_token.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import * as dotenv from "dotenv";
+import { NetworkClientWrapper } from "../utils/testnetClient";
+import { AccountData } from "../utils/testnetUtils";
+import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
+import { LangchainAgent } from "../utils/langchainAgent";
+import { NetworkType } from "../types";
+import { wait } from "../utils/utils";
+
+const IS_CUSTODIAL = true;
+
+dotenv.config();
+describe("dissociate_token", () => {
+  let tokenCreatorAccount: AccountData;
+  let token1: string;
+  let token2: string;
+  let networkClientWrapper: NetworkClientWrapper;
+  let langchainAgent: LangchainAgent;
+  let testCases: {
+    tokenToDissociateId: string;
+    promptText: string;
+  }[];
+  let hederaMirrorNodeClient: HederaMirrorNodeClient;
+
+  beforeAll(async () => {
+    try {
+      langchainAgent = await LangchainAgent.create();
+      hederaMirrorNodeClient = new HederaMirrorNodeClient("testnet" as NetworkType);
+
+      networkClientWrapper = new NetworkClientWrapper(
+        process.env.HEDERA_ACCOUNT_ID!,
+        process.env.HEDERA_PRIVATE_KEY!,
+        process.env.HEDERA_KEY_TYPE!,
+        "testnet"
+      );
+
+      // Create a test account
+      const startingHbars = 20;
+      const autoAssociation = 0; // no auto association
+      tokenCreatorAccount = await networkClientWrapper.createAccount(
+        startingHbars,
+        autoAssociation
+      );
+
+      const tokenCreatorAccountNetworkClientWrapper =
+        new NetworkClientWrapper(
+          tokenCreatorAccount.accountId,
+          tokenCreatorAccount.privateKey,
+          "ECDSA",
+          "testnet"
+        );
+
+      // create tokens
+      await Promise.all([
+        tokenCreatorAccountNetworkClientWrapper.createFT({
+          name: "TokenToDissociate1",
+          symbol: "TTD1",
+          initialSupply: 1000,
+          decimals: 2,
+        }),
+        tokenCreatorAccountNetworkClientWrapper.createFT({
+          name: "TokenToDissociate2",
+          symbol: "TTD2",
+          initialSupply: 1000,
+          decimals: 2,
+        }),
+      ]).then(([_token1, _token2]) => {
+        token1 = _token1;
+        token2 = _token2;
+      });
+
+      await wait(3000);
+
+      // associate with those tokens
+      await networkClientWrapper.associateToken(token1);
+      await networkClientWrapper.associateToken(token2);
+
+      await wait(3000);
+
+      testCases = [
+        {
+          tokenToDissociateId: token1,
+          promptText: `Dissociate token ${token1} from my account`,
+        },
+        {
+          tokenToDissociateId: token2,
+          promptText: `Dissociate token ${token2} from my account`,
+        },
+      ];
+    } catch (error) {
+      console.error("Error in setup:", error);
+      throw error;
+    }
+  });
+
+  describe("dissociate token checks", () => {
+    it("should dissociate token", async () => {
+      for (const { promptText, tokenToDissociateId } of testCases || []) {
+        const prompt = {
+          user: "user",
+          text: promptText,
+        };
+
+        console.log(`Prompt: ${promptText}`);
+
+        // STEP 1: send custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL);
+
+        await wait(5000);
+
+        // STEP 2: verify correctness by checking that token was dissociated
+        const token = await hederaMirrorNodeClient.getAccountToken(
+          networkClientWrapper.getAccountId(),
+          tokenToDissociateId
+        );
+
+        expect(token).toBeUndefined();
+
+        console.log('\n\n');
+      }
+    });
+  });
+});

--- a/src/tests/custodial/dissociate_token.test.ts
+++ b/src/tests/custodial/dissociate_token.test.ts
@@ -69,13 +69,9 @@ describe("dissociate_token", () => {
         token2 = _token2;
       });
 
-      await wait(3000);
-
       // associate with those tokens
       await networkClientWrapper.associateToken(token1);
       await networkClientWrapper.associateToken(token2);
-
-      await wait(3000);
 
       testCases = [
         {
@@ -106,7 +102,7 @@ describe("dissociate_token", () => {
         // STEP 1: send custodial prompt
         const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL);
 
-        await wait(5000);
+        await wait(5000); // wait for the mirror node to update
 
         // STEP 2: verify correctness by checking that token was dissociated
         const token = await hederaMirrorNodeClient.getAccountToken(

--- a/src/tests/custodial/reject_token.test.ts
+++ b/src/tests/custodial/reject_token.test.ts
@@ -90,7 +90,6 @@ describe("reject_token", async () => {
             });
 
             // Define test cases using created accounts and tokens
-            //FIXME: failing
             await Promise.all([
                 airdropCreatorNetworkClientWrapper.airdropToken(token1, [
                     {

--- a/src/tests/custodial/token_airdrop.test.ts
+++ b/src/tests/custodial/token_airdrop.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, beforeAll } from "vitest";
-
 import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
 import * as dotenv from "dotenv";
 import { NetworkClientWrapper } from "../utils/testnetClient";
 import { AccountData } from "../utils/testnetUtils";
 import { LangchainAgent } from "../utils/langchainAgent";
+import { formatTxHash } from "../utils/utils";
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -44,16 +44,6 @@ function extractLangchainResponse(
 
   return null;
 }
-
-const formatTxHash = (txHash: string) => {
-  const [txId, txTimestamp] = txHash.split("@");
-
-  if (!txId || !txTimestamp) {
-    throw new Error("Invalid tx hash");
-  }
-
-  return `${txId}-${txTimestamp?.replace(".", "-")}`;
-};
 
 describe("Test Token Airdrop", async () => {
   let acc1: AccountData;

--- a/src/tests/custodial/transfer_hbar.test.ts
+++ b/src/tests/custodial/transfer_hbar.test.ts
@@ -4,7 +4,7 @@ import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
 import * as dotenv from "dotenv";
 import { NetworkClientWrapper } from "../utils/testnetClient";
 import { AccountData } from "../utils/testnetUtils";
-import { wait } from "../utils/utils";
+import { formatTxHash, wait } from "../utils/utils";
 
 const IS_CUSTODIAL = true;
 
@@ -24,15 +24,6 @@ const extractTxHash = (messages: any[]) => {
   }, "");
 };
 
-const formatTxHash = (txHash: string) => {
-  const [txId, txTimestamp] = txHash.split("@");
-
-  if (!txId || !txTimestamp) {
-    throw new Error("Invalid tx hash");
-  }
-
-  return `${txId}-${txTimestamp?.replace(".", "-")}`;
-};
 
 describe("Test HBAR transfer", async () => {
   let acc1: AccountData;

--- a/src/tests/custodial/transfer_hts.test.ts
+++ b/src/tests/custodial/transfer_hts.test.ts
@@ -4,7 +4,7 @@ import * as dotenv from "dotenv";
 import { NetworkClientWrapper } from "../utils/testnetClient";
 import { AccountData } from "../utils/testnetUtils";
 import { LangchainAgent } from "../utils/langchainAgent";
-import { wait } from "../utils/utils";
+import { formatTxHash, wait } from "../utils/utils";
 
 const IS_CUSTODIAL = true;
 
@@ -36,15 +36,6 @@ const extractTransferDetails = (
   }, null);
 };
 
-const formatTxHash = (txHash: string) => {
-  const [txId, txTimestamp] = txHash.split("@");
-
-  if (!txId || !txTimestamp) {
-    throw new Error("Invalid tx hash");
-  }
-
-  return `${txId}-${txTimestamp?.replace(".", "-")}`;
-};
 
 describe("Test Token transfer", async () => {
   let acc1: AccountData;

--- a/src/tests/non-custodial/associate_token.test.ts
+++ b/src/tests/non-custodial/associate_token.test.ts
@@ -143,7 +143,6 @@ describe("associate_token (non-custodial)", () => {
         expect(token).toBeDefined();
 
         console.log('\n\n');
-        await wait(5000);
       }
     });
   });

--- a/src/tests/non-custodial/associate_token.test.ts
+++ b/src/tests/non-custodial/associate_token.test.ts
@@ -11,7 +11,7 @@ import { ExecutorAccountDetails } from "../../types";
 const IS_CUSTODIAL = false;
 
 dotenv.config();
-describe("associate_token non-custodial", () => {
+describe("associate_token (non-custodial)", () => {
   let tokenCreatorAccount: AccountData;
   let txExecutorAccount: AccountData;
   let token1: string;

--- a/src/tests/non-custodial/associate_token.test.ts
+++ b/src/tests/non-custodial/associate_token.test.ts
@@ -143,7 +143,7 @@ describe("associate_token (non-custodial)", () => {
         expect(token).toBeDefined();
 
         console.log('\n\n');
-        await wait(2000);
+        await wait(5000);
       }
     });
   });

--- a/src/tests/non-custodial/associate_token.test.ts
+++ b/src/tests/non-custodial/associate_token.test.ts
@@ -49,15 +49,6 @@ describe("associate_token (non-custodial)", () => {
         autoAssociation
       );
 
-      const maxAutoAssociationForTest =
-        await hederaMirrorNodeClient.getAutomaticAssociationsCount(
-          networkClientWrapper.getAccountId()
-        );
-
-      await networkClientWrapper.setMaxAutoAssociation(
-        maxAutoAssociationForTest
-      );
-
       const tokenCreatorAccountNetworkClientWrapper =
         new NetworkClientWrapper(
           tokenCreatorAccount.accountId,
@@ -89,7 +80,7 @@ describe("associate_token (non-custodial)", () => {
       testCases = [
         {
           tokenToAssociateId: token1,
-          promptText: `Associate token ${token1} to my account}`,
+          promptText: `Associate token ${token1} to my account`,
         },
         {
           tokenToAssociateId: token2,

--- a/src/tests/non-custodial/claim_airdrop.test.ts
+++ b/src/tests/non-custodial/claim_airdrop.test.ts
@@ -109,14 +109,14 @@ describe("claim_pending_airdrops (non-custodial)", () => {
 
             testCases = [
                 {
-                    receiverAccountId: networkClientWrapper.getAccountId(),
+                    receiverAccountId: txExecutorAccount.accountId,
                     senderAccountId: airdropCreatorAccount.accountId,
                     tokenId: token1,
                     promptText: `Claim airdrop for token ${token1} from sender ${airdropCreatorAccount.accountId}`,
                     expectedClaimedAmount: 10,
                 },
                 {
-                    receiverAccountId: networkClientWrapper.getAccountId(),
+                    receiverAccountId: txExecutorAccount.accountId,
                     senderAccountId: airdropCreatorAccount.accountId,
                     tokenId: token2,
                     promptText: `Claim airdrop for token ${token2} from sender ${airdropCreatorAccount.accountId}`,
@@ -153,7 +153,6 @@ describe("claim_pending_airdrops (non-custodial)", () => {
                     executorPublicKey: txExecutorAccount.publicKey,
                 }
 
-                // FIXME: fails in non-custodial mode
                 // STEP 1: send non-custodial prompt
                 const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
 

--- a/src/tests/non-custodial/claim_airdrop.test.ts
+++ b/src/tests/non-custodial/claim_airdrop.test.ts
@@ -1,4 +1,4 @@
-import { describe, beforeAll, expect, it, afterAll } from "vitest";
+import { describe, beforeAll, expect, it } from "vitest";
 import { AccountData } from "../utils/testnetUtils";
 import { LangchainAgent } from "../utils/langchainAgent";
 import { NetworkClientWrapper } from "../utils/testnetClient";
@@ -6,7 +6,6 @@ import * as dotenv from "dotenv";
 import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
 import { extractTxBytes, signAndExecuteTx, wait } from "../utils/utils";
 import { ExecutorAccountDetails } from "../../types";
-import { PrivateKey } from "@hashgraph/sdk";
 
 const IS_CUSTODIAL = false;
 

--- a/src/tests/non-custodial/claim_airdrop.test.ts
+++ b/src/tests/non-custodial/claim_airdrop.test.ts
@@ -48,7 +48,7 @@ describe("claim_pending_airdrops (non-custodial)", () => {
               0 // no auto association
             );
 
-            await wait(3000);
+            await wait(3000); // waiting for the account to be created on the network.
 
             const airdropCreatorAccountNetworkClientWrapper =
               new NetworkClientWrapper(
@@ -77,7 +77,7 @@ describe("claim_pending_airdrops (non-custodial)", () => {
                 token2 = _token2;
             });
 
-            await wait(3000);
+            await wait(3000); // waiting for the tokens to be created on the network.
 
             // airdrop tokens
             await Promise.all([
@@ -95,7 +95,7 @@ describe("claim_pending_airdrops (non-custodial)", () => {
                 ]),
             ]);
 
-            await wait(5000);
+            await wait(3000); // waiting for the airdrop to be executed on the network.
 
 
             testCases = [

--- a/src/tests/non-custodial/claim_airdrop.test.ts
+++ b/src/tests/non-custodial/claim_airdrop.test.ts
@@ -155,8 +155,7 @@ describe("claim_pending_airdrops (non-custodial)", () => {
                     executorPublicKey: txExecutorAccount.publicKey,
                 }
 
-                console.log('Transaction will be performed for: ' + JSON.stringify(executorAccountDetails, null, 2));
-
+                // FIXME: fails in non-custodial mode
                 // STEP 1: send non-custodial prompt
                 const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
 

--- a/src/tests/non-custodial/claim_airdrop.test.ts
+++ b/src/tests/non-custodial/claim_airdrop.test.ts
@@ -21,7 +21,6 @@ describe("claim_pending_airdrops (non-custodial)", () => {
         expectedClaimedAmount: number;
     }[];
     let networkClientWrapper: NetworkClientWrapper;
-    let executorCustodialClientWrapper: NetworkClientWrapper;
     let txExecutorAccount: AccountData;
     let hederaApiClient: HederaMirrorNodeClient;
 
@@ -50,14 +49,6 @@ describe("claim_pending_airdrops (non-custodial)", () => {
             );
 
             await wait(3000);
-
-            // a custodial client wrapper for the tx executor account is required for creating topics before the test
-            executorCustodialClientWrapper = new NetworkClientWrapper(
-              txExecutorAccount.accountId,
-              txExecutorAccount.privateKey,
-              'ECDSA', // .createAccount() creates account with ECDSA key
-              "testnet"
-            );
 
             const airdropCreatorAccountNetworkClientWrapper =
               new NetworkClientWrapper(

--- a/src/tests/non-custodial/claim_airdrop.test.ts
+++ b/src/tests/non-custodial/claim_airdrop.test.ts
@@ -48,8 +48,6 @@ describe("claim_pending_airdrops (non-custodial)", () => {
               0 // no auto association
             );
 
-            await wait(3000); // waiting for the account to be created on the network.
-
             const airdropCreatorAccountNetworkClientWrapper =
               new NetworkClientWrapper(
                 airdropCreatorAccount.accountId,
@@ -77,8 +75,6 @@ describe("claim_pending_airdrops (non-custodial)", () => {
                 token2 = _token2;
             });
 
-            await wait(3000); // waiting for the tokens to be created on the network.
-
             // airdrop tokens
             await Promise.all([
                 airdropCreatorAccountNetworkClientWrapper.airdropToken(token1, [
@@ -94,9 +90,6 @@ describe("claim_pending_airdrops (non-custodial)", () => {
                     },
                 ]),
             ]);
-
-            await wait(3000); // waiting for the airdrop to be executed on the network.
-
 
             testCases = [
                 {
@@ -157,7 +150,7 @@ describe("claim_pending_airdrops (non-custodial)", () => {
                   txExecutorAccount.accountId
                 )
 
-                await wait(5000); // wait for tx to be executed
+                await wait(5000); // wait for the mirror node to update
 
                 const tokenBalance = await hederaApiClient.getTokenBalance(
                   receiverAccountId,

--- a/src/tests/non-custodial/claim_airdrop.test.ts
+++ b/src/tests/non-custodial/claim_airdrop.test.ts
@@ -14,7 +14,6 @@ describe("claim_pending_airdrops (non-custodial)", () => {
     let airdropCreatorAccount: AccountData;
     let token1: string;
     let token2: string;
-    let claimerInitialMaxAutoAssociation: number;
     let testCases: {
         receiverAccountId: string;
         senderAccountId: string;
@@ -42,7 +41,7 @@ describe("claim_pending_airdrops (non-custodial)", () => {
 
             // Create test accounts
             airdropCreatorAccount = await networkClientWrapper.createAccount(
-                20, // starting HBARs
+              20, // starting HBARs
               0 // no auto association
             );
 
@@ -177,6 +176,8 @@ describe("claim_pending_airdrops (non-custodial)", () => {
                 );
 
                 expect(tokenBalance ?? 0).toBe(expectedClaimedAmount);
+
+                console.log('\n\n');
             }
         });
     })

--- a/src/tests/non-custodial/create_fungible_token.test.ts
+++ b/src/tests/non-custodial/create_fungible_token.test.ts
@@ -25,7 +25,7 @@ describe("create_fungible_token (non-custodial)", () => {
       "testnet"
     );
 
-    // Create test account
+    // Create a test account
     const startingHbars = 60;
     const autoAssociation = -1; // unlimited auto association
     txExecutorAccount = await networkClientWrapper.createAccount(

--- a/src/tests/non-custodial/create_fungible_token.test.ts
+++ b/src/tests/non-custodial/create_fungible_token.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
 import * as dotenv from "dotenv";
 import { extractTxBytes, formatTxHash, signAndExecuteTx, wait } from "../utils/utils";
@@ -472,4 +472,8 @@ describe("create_fungible_token (non-custodial)", () => {
 
     expect(Number(tokenDetails.initial_supply) / Math.pow(10, Number(tokenDetails.decimals))).toEqual(75.0);
   });
+
+  afterEach(() => {
+    console.log("\n\n");
+  })
 });

--- a/src/tests/non-custodial/create_fungible_token.test.ts
+++ b/src/tests/non-custodial/create_fungible_token.test.ts
@@ -1,0 +1,475 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
+import * as dotenv from "dotenv";
+import { extractTxBytes, formatTxHash, signAndExecuteTx, wait } from "../utils/utils";
+import { LangchainAgent } from "../utils/langchainAgent";
+import { NetworkClientWrapper } from "../utils/testnetClient";
+import { AccountData } from "../utils/testnetUtils";
+import { ExecutorAccountDetails } from "../../types";
+
+const IS_CUSTODIAL = false;
+
+dotenv.config();
+describe("create_fungible_token (non-custodial)", () => {
+  let hederaApiClient: HederaMirrorNodeClient;
+  let networkClientWrapper: NetworkClientWrapper;
+  let txExecutorAccount: AccountData;
+
+  beforeAll(async () => {
+    hederaApiClient = new HederaMirrorNodeClient("testnet");
+
+    networkClientWrapper = new NetworkClientWrapper(
+      process.env.HEDERA_ACCOUNT_ID!,
+      process.env.HEDERA_PRIVATE_KEY!,
+      process.env.HEDERA_KEY_TYPE!,
+      "testnet"
+    );
+
+    // Create test account
+    const startingHbars = 60;
+    const autoAssociation = -1; // unlimited auto association
+    txExecutorAccount = await networkClientWrapper.createAccount(
+      startingHbars,
+      autoAssociation
+    );
+
+  })
+
+  it("Create token with all possible parameters", async () => {
+    const promptText =
+      "Create token GameGold with symbol GG, 2 decimal places, and starting supply of 7500. Set memo to 'This is an example memo' and token metadata to 'And that's an example metadata'. Add supply key, admin key. Set metadata key.";
+    const prompt = {
+      user: "user",
+      text: promptText,
+    };
+
+    const langchainAgent = await LangchainAgent.create();
+
+    console.log(`Prompt: ${promptText}`);
+    console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+    const executorAccountDetails: ExecutorAccountDetails = {
+      executorAccountId: txExecutorAccount.accountId,
+      executorPublicKey: txExecutorAccount.publicKey,
+    }
+
+    // STEP 1: send non-custodial prompt
+    const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+    // STEP 2: extract tx bytes
+    const txBytesString = extractTxBytes(response.messages)
+
+    // STEP 3: verify correctness by signing and executing the tx
+    const executedTx = await signAndExecuteTx(
+      txBytesString,
+      txExecutorAccount.privateKey,
+      txExecutorAccount.accountId
+    )
+
+    await wait(5000); // wait for tx to be executed
+
+    // STEP 4: verify that the token was created correctly
+    const tokenId = await hederaApiClient.getTransactionDetails(
+      formatTxHash(executedTx.txHash),
+    ).then((tx) => tx.entity_id);
+
+    const tokenDetails = await hederaApiClient.getTokenDetails(
+      tokenId
+    );
+
+    expect(tokenDetails.symbol).toEqual("GG");
+    expect(tokenDetails.name).toEqual("GameGold");
+    expect(tokenDetails.decimals).toEqual("2");
+    expect(Number(tokenDetails.initial_supply) / Math.pow(10, Number(tokenDetails.decimals))).toEqual(7500);
+    expect(tokenDetails.memo).toEqual("This is an example memo");
+    expect(atob(tokenDetails.metadata!)).toEqual(
+      "And that's an example metadata"
+    );
+    expect(tokenDetails?.supply_key?.key).not.toBeFalsy();
+    expect(tokenDetails?.admin_key?.key).not.toBeFalsy();
+    expect(tokenDetails?.metadata_key?.key).not.toBeFalsy();
+  });
+
+  it("Create token with minimal parameters", async () => {
+    const promptText =
+      "Create token Minimal Token with symbol MT, 3 decimal places, and starting supply of 333.";
+    const prompt = {
+      user: "user",
+      text: promptText,
+    };
+    const langchainAgent = await LangchainAgent.create();
+
+    console.log(`Prompt: ${promptText}`);
+    console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+    const executorAccountDetails: ExecutorAccountDetails = {
+      executorAccountId: txExecutorAccount.accountId,
+      executorPublicKey: txExecutorAccount.publicKey,
+    }
+
+    // STEP 1: send non-custodial prompt
+    const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+    // STEP 2: extract tx bytes
+    const txBytesString = extractTxBytes(response.messages)
+
+    // STEP 3: verify correctness by signing and executing the tx
+    const executedTx = await signAndExecuteTx(
+      txBytesString,
+      txExecutorAccount.privateKey,
+      txExecutorAccount.accountId
+    )
+
+    await wait(5000); // wait for tx to be executed
+
+    // STEP 4: verify that token was created correctly
+    const tokenId = await hederaApiClient.getTransactionDetails(
+      formatTxHash(executedTx.txHash),
+    ).then((tx) => tx.entity_id);
+
+    const tokenDetails = await hederaApiClient.getTokenDetails(
+      tokenId
+    );
+
+    expect(tokenDetails.symbol).toEqual("MT");
+    expect(tokenDetails.name).toEqual("Minimal Token");
+    expect(tokenDetails.decimals).toEqual("3");
+    expect(Number(tokenDetails.initial_supply) / Math.pow(10, Number(tokenDetails.decimals))).toEqual(333);
+    expect(tokenDetails.memo).toBe("");
+    expect(tokenDetails.metadata).toBe("");
+    expect(tokenDetails?.supply_key?.key).toBeUndefined();
+    expect(tokenDetails?.admin_key?.key).toBeUndefined();
+    expect(tokenDetails?.metadata_key?.key).toBeUndefined();
+  });
+
+  it("Create token with minimal parameters plus memo", async () => {
+    const promptText =
+      "Create token 'Minimal Plus Memo Token' with symbol MPMT, 4 decimal places, and starting supply of 444. Set memo to 'Automatic tests memo'";
+    const prompt = {
+      user: "user",
+      text: promptText,
+    };
+    const langchainAgent = await LangchainAgent.create();
+
+    console.log(`Prompt: ${promptText}`);
+    console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+    const executorAccountDetails: ExecutorAccountDetails = {
+      executorAccountId: txExecutorAccount.accountId,
+      executorPublicKey: txExecutorAccount.publicKey,
+    }
+
+    // STEP 1: send non-custodial prompt
+    const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+    // STEP 2: extract tx bytes
+    const txBytesString = extractTxBytes(response.messages)
+
+    // STEP 3: verify correctness by signing and executing the tx
+    const executedTx = await signAndExecuteTx(
+      txBytesString,
+      txExecutorAccount.privateKey,
+      txExecutorAccount.accountId
+    )
+
+    await wait(5000); // wait for tx to be executed
+
+    // STEP 4: verify that the token was created correctly
+    const tokenId = await hederaApiClient.getTransactionDetails(
+      formatTxHash(executedTx.txHash),
+    ).then((tx) => tx.entity_id);
+
+    const tokenDetails = await hederaApiClient.getTokenDetails(tokenId);
+
+    expect(tokenDetails.symbol).toEqual("MPMT");
+    expect(tokenDetails.name).toEqual("Minimal Plus Memo Token");
+    expect(tokenDetails.decimals).toEqual("4");
+    expect(Number(tokenDetails.initial_supply) / Math.pow(10, Number(tokenDetails.decimals))).toEqual(444);
+    expect(tokenDetails.memo).toEqual("Automatic tests memo");
+    expect(tokenDetails.metadata).toBe("");
+    expect(tokenDetails?.supply_key?.key).toBeUndefined();
+    expect(tokenDetails?.admin_key?.key).toBeUndefined();
+    expect(tokenDetails?.metadata_key?.key).toBeUndefined();
+  });
+
+  it("Create token with minimal parameters plus metadata key", async () => {
+    const promptText =
+      "Create token 'Minimal Plus Metadata Key Token' with symbol MPMKT, 5 decimal places, and starting supply of 555. Set metadata key to agents key.";
+    const prompt = {
+      user: "user",
+      text: promptText,
+    };
+    const langchainAgent = await LangchainAgent.create();
+
+    console.log(`Prompt: ${promptText}`);
+    console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+    const executorAccountDetails: ExecutorAccountDetails = {
+      executorAccountId: txExecutorAccount.accountId,
+      executorPublicKey: txExecutorAccount.publicKey,
+    }
+
+    // STEP 1: send non-custodial prompt
+    const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+    // STEP 2: extract tx bytes
+    const txBytesString = extractTxBytes(response.messages)
+
+    // STEP 3: verify correctness by signing and executing the tx
+    const executedTx = await signAndExecuteTx(
+      txBytesString,
+      txExecutorAccount.privateKey,
+      txExecutorAccount.accountId
+    )
+
+    await wait(5000); // wait for tx to be executed
+
+    // STEP 4: verify that the token was created correctly
+    const tokenId = await hederaApiClient.getTransactionDetails(
+      formatTxHash(executedTx.txHash),
+    ).then((tx) => tx.entity_id);
+
+    const tokenDetails = await hederaApiClient.getTokenDetails(tokenId);
+
+    expect(tokenDetails.symbol).toEqual("MPMKT");
+    expect(tokenDetails.name).toEqual("Minimal Plus Metadata Key Token");
+    expect(tokenDetails.decimals).toEqual("5");
+    expect(Number(tokenDetails.initial_supply) / Math.pow(10, Number(tokenDetails.decimals))).toEqual(555);
+    expect(tokenDetails.memo).toBe("");
+    expect(tokenDetails.metadata).toBe("");
+    expect(tokenDetails?.supply_key?.key).toBeUndefined();
+    expect(tokenDetails?.admin_key?.key).toBeUndefined();
+    expect(tokenDetails?.metadata_key?.key).not.toBeUndefined();
+  });
+
+  it("Create token with minimal parameters plus admin key and supply key", async () => {
+    const promptText =
+      "Create token 'Minimal Plus Admin Supply Keys Token' with symbol MPASKT, 1 decimal places, and starting supply of 111. Set admin key and supply keys.";
+    const prompt = {
+      user: "user",
+      text: promptText,
+    };
+    const langchainAgent = await LangchainAgent.create();
+
+    console.log(`Prompt: ${promptText}`);
+    console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+    const executorAccountDetails: ExecutorAccountDetails = {
+      executorAccountId: txExecutorAccount.accountId,
+      executorPublicKey: txExecutorAccount.publicKey,
+    }
+
+    // STEP 1: send non-custodial prompt
+    const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+    // STEP 2: extract tx bytes
+    const txBytesString = extractTxBytes(response.messages)
+
+    // STEP 3: verify correctness by signing and executing the tx
+    const executedTx = await signAndExecuteTx(
+      txBytesString,
+      txExecutorAccount.privateKey,
+      txExecutorAccount.accountId
+    )
+
+    await wait(5000); // wait for tx to be executed
+
+    // STEP 4: verify that the token was created correctly
+    const tokenId = await hederaApiClient.getTransactionDetails(
+      formatTxHash(executedTx.txHash),
+    ).then((tx) => tx.entity_id);
+
+    const tokenDetails = await hederaApiClient.getTokenDetails(tokenId);
+
+    expect(tokenDetails.symbol).toEqual("MPASKT");
+    expect(tokenDetails.name).toEqual("Minimal Plus Admin Supply Keys Token");
+    expect(tokenDetails.decimals).toEqual("1");
+    expect(Number(tokenDetails.initial_supply) / Math.pow(10, Number(tokenDetails.decimals))).toEqual(111);
+    expect(tokenDetails.memo).toBe("");
+    expect(tokenDetails?.supply_key?.key).not.toBeUndefined();
+    expect(tokenDetails?.admin_key?.key).not.toBeUndefined();
+    expect(tokenDetails?.metadata_key?.key).toBeUndefined();
+  });
+
+  it("Create token with minimal parameters plus admin key and supply key and memo and metadata", async () => {
+    const promptText =
+      "Create token 'Complex Token' with symbol CPLXT, 1 decimal places, and starting supply of 1111. Set admin key and supply keys. Set memo to 'This a complex token'. Set metadata to 'this could be a link to image'. Don't set metadata key";
+    const prompt = {
+      user: "user",
+      text: promptText,
+    };
+    const langchainAgent = await LangchainAgent.create();
+
+    console.log(`Prompt: ${promptText}`);
+    console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+    const executorAccountDetails: ExecutorAccountDetails = {
+      executorAccountId: txExecutorAccount.accountId,
+      executorPublicKey: txExecutorAccount.publicKey,
+    }
+
+    // STEP 1: send non-custodial prompt
+    const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+    // STEP 2: extract tx bytes
+    const txBytesString = extractTxBytes(response.messages)
+
+    // STEP 3: verify correctness by signing and executing the tx
+    const executedTx = await signAndExecuteTx(
+      txBytesString,
+      txExecutorAccount.privateKey,
+      txExecutorAccount.accountId
+    )
+
+    await wait(5000); // wait for tx to be executed
+
+    // STEP 4: verify that token was created correctly
+    const tokenId = await hederaApiClient.getTransactionDetails(
+      formatTxHash(executedTx.txHash),
+    ).then((tx) => tx.entity_id);
+
+    const tokenDetails = await hederaApiClient.getTokenDetails(tokenId);
+
+    expect(tokenDetails.symbol).toEqual("CPLXT");
+    expect(tokenDetails.name).toEqual("Complex Token");
+    expect(tokenDetails.decimals).toEqual("1");
+    expect(Number(tokenDetails.initial_supply) / Math.pow(10, Number(tokenDetails.decimals))).toEqual(1111);
+    expect(tokenDetails.memo).toBe("This a complex token");
+    expect(atob(tokenDetails.metadata!)).toBe("this could be a link to image");
+    expect(tokenDetails?.supply_key?.key).not.toBeUndefined();
+    expect(tokenDetails?.admin_key?.key).not.toBeUndefined();
+    expect(tokenDetails?.metadata_key?.key).toBeUndefined();
+  });
+
+  it("Create token with supply in display units using comma", async () => {
+    const promptText =
+      "Create token GameGold with symbol GG, 2 decimal places, and starting supply of 75,55";
+    const prompt = {
+      user: "user",
+      text: promptText,
+    };
+    const langchainAgent = await LangchainAgent.create();
+
+    console.log(`Prompt: ${promptText}`);
+    console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+    const executorAccountDetails: ExecutorAccountDetails = {
+      executorAccountId: txExecutorAccount.accountId,
+      executorPublicKey: txExecutorAccount.publicKey,
+    }
+
+    // STEP 1: send non-custodial prompt
+    const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+    // STEP 2: extract tx bytes
+    const txBytesString = extractTxBytes(response.messages)
+
+    // STEP 3: verify correctness by signing and executing the tx
+    const executedTx = await signAndExecuteTx(
+      txBytesString,
+      txExecutorAccount.privateKey,
+      txExecutorAccount.accountId
+    )
+
+    await wait(5000); // wait for tx to be executed
+
+    // STEP 4: verify that the token was created correctly
+    const tokenId = await hederaApiClient.getTransactionDetails(
+      formatTxHash(executedTx.txHash),
+    ).then((tx) => tx.entity_id);
+
+    const tokenDetails = await hederaApiClient.getTokenDetails(
+      tokenId
+    );
+
+    expect(Number(tokenDetails.initial_supply) / Math.pow(10, Number(tokenDetails.decimals))).toEqual(75.55);
+  });
+
+  it("Create token with supply in display units using dot", async () => {
+    const promptText =
+      "Create token GameGold with symbol GG, 2 decimal places, and starting supply of 75.55";
+    const prompt = {
+      user: "user",
+      text: promptText,
+    };
+    const langchainAgent = await LangchainAgent.create();
+
+    console.log(`Prompt: ${promptText}`);
+    console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+    const executorAccountDetails: ExecutorAccountDetails = {
+      executorAccountId: txExecutorAccount.accountId,
+      executorPublicKey: txExecutorAccount.publicKey,
+    }
+
+    // STEP 1: send non-custodial prompt
+    const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+    // STEP 2: extract tx bytes
+    const txBytesString = extractTxBytes(response.messages)
+
+    // STEP 3: verify correctness by signing and executing the tx
+    const executedTx = await signAndExecuteTx(
+      txBytesString,
+      txExecutorAccount.privateKey,
+      txExecutorAccount.accountId
+    )
+
+    await wait(5000); // wait for tx to be executed
+
+    // STEP 4: verify that the token was created correctly
+    const tokenId = await hederaApiClient.getTransactionDetails(
+      formatTxHash(executedTx.txHash),
+    ).then((tx) => tx.entity_id);
+
+    const tokenDetails = await hederaApiClient.getTokenDetails(
+      tokenId
+    );
+
+    expect(Number(tokenDetails.initial_supply) / Math.pow(10, Number(tokenDetails.decimals))).toEqual(75.55);
+  });
+
+  it("Create token with supply in display units using dot and zero", async () => {
+    const promptText =
+      "Create token GameGold with symbol GG, 2 decimal places, and starting supply of 75.0";
+    const prompt = {
+      user: "user",
+      text: promptText,
+    };
+    const langchainAgent = await LangchainAgent.create();
+
+    console.log(`Prompt: ${promptText}`);
+    console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+    const executorAccountDetails: ExecutorAccountDetails = {
+      executorAccountId: txExecutorAccount.accountId,
+      executorPublicKey: txExecutorAccount.publicKey,
+    }
+
+    // STEP 1: send non-custodial prompt
+    const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+    // STEP 2: extract tx bytes
+    const txBytesString = extractTxBytes(response.messages)
+
+    // STEP 3: verify correctness by signing and executing the tx
+    const executedTx = await signAndExecuteTx(
+      txBytesString,
+      txExecutorAccount.privateKey,
+      txExecutorAccount.accountId
+    )
+
+    await wait(5000); // wait for tx to be executed
+
+    // STEP 4: verify that the token was created correctly
+    const tokenId = await hederaApiClient.getTransactionDetails(
+      formatTxHash(executedTx.txHash),
+    ).then((tx) => tx.entity_id);
+
+    const tokenDetails = await hederaApiClient.getTokenDetails(
+      tokenId
+    );
+
+    expect(Number(tokenDetails.initial_supply) / Math.pow(10, Number(tokenDetails.decimals))).toEqual(75.0);
+  });
+});

--- a/src/tests/non-custodial/create_fungible_token.test.ts
+++ b/src/tests/non-custodial/create_fungible_token.test.ts
@@ -33,6 +33,7 @@ describe("create_fungible_token (non-custodial)", () => {
       autoAssociation
     );
 
+    await wait(3000); // wait for the account to be created
   })
 
   it("Create token with all possible parameters", async () => {

--- a/src/tests/non-custodial/create_fungible_token.test.ts
+++ b/src/tests/non-custodial/create_fungible_token.test.ts
@@ -33,7 +33,6 @@ describe("create_fungible_token (non-custodial)", () => {
       autoAssociation
     );
 
-    await wait(3000); // wait for the account to be created
   })
 
   it("Create token with all possible parameters", async () => {
@@ -67,7 +66,7 @@ describe("create_fungible_token (non-custodial)", () => {
       txExecutorAccount.accountId
     )
 
-    await wait(5000); // wait for tx to be executed
+    await wait(5000); // wait for the mirror node to be updated
 
     // STEP 4: verify that the token was created correctly
     const tokenId = await hederaApiClient.getTransactionDetails(
@@ -121,7 +120,7 @@ describe("create_fungible_token (non-custodial)", () => {
       txExecutorAccount.accountId
     )
 
-    await wait(5000); // wait for tx to be executed
+    await wait(5000); // wait for the mirror node to be updated
 
     // STEP 4: verify that token was created correctly
     const tokenId = await hederaApiClient.getTransactionDetails(
@@ -173,7 +172,7 @@ describe("create_fungible_token (non-custodial)", () => {
       txExecutorAccount.accountId
     )
 
-    await wait(5000); // wait for tx to be executed
+    await wait(5000); // wait for the mirror node to be updated
 
     // STEP 4: verify that the token was created correctly
     const tokenId = await hederaApiClient.getTransactionDetails(
@@ -223,7 +222,7 @@ describe("create_fungible_token (non-custodial)", () => {
       txExecutorAccount.accountId
     )
 
-    await wait(5000); // wait for tx to be executed
+    await wait(5000); // wait for the mirror node to be updated
 
     // STEP 4: verify that the token was created correctly
     const tokenId = await hederaApiClient.getTransactionDetails(
@@ -273,7 +272,7 @@ describe("create_fungible_token (non-custodial)", () => {
       txExecutorAccount.accountId
     )
 
-    await wait(5000); // wait for tx to be executed
+    await wait(5000); // wait for the mirror node to be updated
 
     // STEP 4: verify that the token was created correctly
     const tokenId = await hederaApiClient.getTransactionDetails(
@@ -322,7 +321,7 @@ describe("create_fungible_token (non-custodial)", () => {
       txExecutorAccount.accountId
     )
 
-    await wait(5000); // wait for tx to be executed
+    await wait(5000); // wait for the mirror node to be updated
 
     // STEP 4: verify that token was created correctly
     const tokenId = await hederaApiClient.getTransactionDetails(
@@ -372,7 +371,7 @@ describe("create_fungible_token (non-custodial)", () => {
       txExecutorAccount.accountId
     )
 
-    await wait(5000); // wait for tx to be executed
+    await wait(5000); // wait for the mirror node to be updated
 
     // STEP 4: verify that the token was created correctly
     const tokenId = await hederaApiClient.getTransactionDetails(
@@ -416,7 +415,7 @@ describe("create_fungible_token (non-custodial)", () => {
       txExecutorAccount.accountId
     )
 
-    await wait(5000); // wait for tx to be executed
+    await wait(5000); // wait for the mirror node to be updated
 
     // STEP 4: verify that the token was created correctly
     const tokenId = await hederaApiClient.getTransactionDetails(
@@ -460,7 +459,7 @@ describe("create_fungible_token (non-custodial)", () => {
       txExecutorAccount.accountId
     )
 
-    await wait(5000); // wait for tx to be executed
+    await wait(5000); // wait for the mirror node to update
 
     // STEP 4: verify that the token was created correctly
     const tokenId = await hederaApiClient.getTransactionDetails(

--- a/src/tests/non-custodial/create_nft_token.test.ts
+++ b/src/tests/non-custodial/create_nft_token.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { NetworkType } from "../types";
+import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
+import * as dotenv from "dotenv";
+import { LangchainAgent } from "../utils/langchainAgent";
+import { NetworkClientWrapper } from "../utils/testnetClient";
+import {TokenType} from "@hashgraph/sdk";
+import { AccountData } from "../utils/testnetUtils";
+import { extractTxBytes, formatTxHash, signAndExecuteTx, wait } from "../utils/utils";
+import { ExecutorAccountDetails } from "../../types";
+
+const IS_CUSTODIAL = false;
+
+describe("create_nft_token", () => {
+    let hederaApiClient: HederaMirrorNodeClient;
+    let networkClientWrapper;
+    let txExecutorAccount: AccountData;
+    const INFINITE_SUPPLY = 0;
+
+    beforeAll(async () => {
+        dotenv.config();
+        hederaApiClient = new HederaMirrorNodeClient("testnet" as NetworkType);
+
+        networkClientWrapper = new NetworkClientWrapper(
+          process.env.HEDERA_ACCOUNT_ID!,
+          process.env.HEDERA_PRIVATE_KEY!,
+          process.env.HEDERA_KEY_TYPE!,
+          "testnet"
+        );
+
+        // Create a test account
+        const startingHbars = 60;
+        const autoAssociation = -1; // unlimited auto association
+        txExecutorAccount = await networkClientWrapper.createAccount(
+          startingHbars,
+          autoAssociation
+        );
+    });
+
+    it("Create NFT token with all possible parameters", async () => {
+        const prompt = {
+            user: "user",
+            text: "Create non-fungible token with name TestToken, symbol TT, and max supply of 100. Set memo to 'This is an example memo' and token metadata to 'And that's an example metadata'. Add admin key. Set metadata key.",
+        };
+
+        const langchainAgent = await LangchainAgent.create();
+
+        console.log(`Prompt: ${prompt.text}`);
+        console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+        const executorAccountDetails: ExecutorAccountDetails = {
+            executorAccountId: txExecutorAccount.accountId,
+            executorPublicKey: txExecutorAccount.publicKey,
+        }
+
+        // STEP 1: send non-custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+        // STEP 2: extract tx bytes
+        const txBytesString = extractTxBytes(response.messages)
+
+        // STEP 3: verify correctness by signing and executing the tx
+        const executedTx = await signAndExecuteTx(
+          txBytesString,
+          txExecutorAccount.privateKey,
+          txExecutorAccount.accountId
+        )
+
+        await wait(5000); // wait for tx to be executed
+
+        // STEP 4: verify that the token was created correctly
+        const tokenId = await hederaApiClient.getTransactionDetails(
+          formatTxHash(executedTx.txHash),
+        ).then((tx) => tx.entity_id);
+
+        const tokenDetails = await hederaApiClient.getTokenDetails(tokenId);
+
+        expect(tokenDetails.symbol).toEqual("TT");
+        expect(tokenDetails.name).toEqual("TestToken");
+        expect(tokenDetails.type).toEqual(TokenType.NonFungibleUnique.toString());
+        expect(Number(tokenDetails.max_supply)).toEqual(100);
+        expect(tokenDetails.memo).toEqual("This is an example memo");
+        expect(atob(tokenDetails.metadata!)).toEqual(
+          "And that's an example metadata"
+        );
+        expect(tokenDetails?.supply_key?.key).toBeTruthy(); // all NFTs have a supply key set by default
+        expect(tokenDetails?.admin_key?.key).toBeTruthy();
+        expect(tokenDetails?.metadata_key?.key).toBeTruthy();
+    });
+
+    it("Create without optional keys", async () => {
+        const prompt = {
+            user: "user",
+            text: "Create non-fungible token with name TestToken, symbol TT, and max supply of 100. Set memo to 'This is an example memo' and token metadata to 'And that's an example metadata'. Do not set the metadata and admin keys",
+        };
+
+        const langchainAgent = await LangchainAgent.create();
+
+        console.log(`Prompt: ${prompt.text}`);
+        console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+        const executorAccountDetails: ExecutorAccountDetails = {
+            executorAccountId: txExecutorAccount.accountId,
+            executorPublicKey: txExecutorAccount.publicKey,
+        }
+
+        // STEP 1: send non-custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+        // STEP 2: extract tx bytes
+        const txBytesString = extractTxBytes(response.messages)
+
+        // STEP 3: verify correctness by signing and executing the tx
+        const executedTx = await signAndExecuteTx(
+          txBytesString,
+          txExecutorAccount.privateKey,
+          txExecutorAccount.accountId
+        )
+
+        await wait(5000); // wait for tx to be executed
+
+        // STEP 4: verify that the token was created correctly
+        const tokenId = await hederaApiClient.getTransactionDetails(
+          formatTxHash(executedTx.txHash),
+        ).then((tx) => tx.entity_id);
+
+        const tokenDetails = await hederaApiClient.getTokenDetails(tokenId);
+
+        expect(tokenDetails.symbol).toEqual("TT");
+        expect(tokenDetails.name).toEqual("TestToken");
+        expect(tokenDetails.type).toEqual(TokenType.NonFungibleUnique.toString());
+        expect(Number(tokenDetails.max_supply)).toEqual(100);
+        expect(tokenDetails.memo).toEqual("This is an example memo");
+        expect(atob(tokenDetails.metadata!)).toEqual(
+          "And that's an example metadata"
+        );
+        expect(tokenDetails?.supply_key?.key).toBeTruthy(); // all NFTs have a supply key set by default
+        expect(tokenDetails?.admin_key?.key).toBeFalsy();
+        expect(tokenDetails?.metadata_key?.key).toBeFalsy();
+    });
+
+    it("Create token with minimal parameters", async () => {
+        const prompt = {
+            user: "user",
+            text: "Create non-fungible token with name TestToken, symbol TT.",
+        };
+
+        const langchainAgent = await LangchainAgent.create();
+
+        console.log(`Prompt: ${prompt.text}`);
+        console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+        const executorAccountDetails: ExecutorAccountDetails = {
+            executorAccountId: txExecutorAccount.accountId,
+            executorPublicKey: txExecutorAccount.publicKey,
+        }
+
+        // STEP 1: send non-custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+        // STEP 2: extract tx bytes
+        const txBytesString = extractTxBytes(response.messages)
+
+        // STEP 3: verify correctness by signing and executing the tx
+        const executedTx = await signAndExecuteTx(
+          txBytesString,
+          txExecutorAccount.privateKey,
+          txExecutorAccount.accountId
+        )
+
+        await wait(5000); // wait for tx to be executed
+
+        // STEP 4: verify that the token was created correctly
+        const tokenId = await hederaApiClient.getTransactionDetails(
+          formatTxHash(executedTx.txHash),
+        ).then((tx) => tx.entity_id);
+
+        const tokenDetails = await hederaApiClient.getTokenDetails(tokenId);
+
+        expect(tokenDetails.symbol).toEqual("TT");
+        expect(tokenDetails.name).toEqual("TestToken");
+        expect(tokenDetails.type).toEqual(TokenType.NonFungibleUnique.toString());
+        expect(Number(tokenDetails.max_supply)).toEqual(INFINITE_SUPPLY);
+        expect(tokenDetails.memo).toEqual("");
+        expect(tokenDetails.metadata).toEqual("");
+        expect(tokenDetails?.supply_key?.key).toBeTruthy(); // all NFTs have a supply key set by default
+        expect(tokenDetails?.admin_key?.key).toBeFalsy();
+        expect(tokenDetails?.metadata_key?.key).toBeFalsy();
+    });
+
+    it("Create token with minimal parameters plus memo and max supply", async () => {
+        const prompt = {
+            user: "user",
+            text: "Create non-fungible token with name TestToken, symbol TT. Set memo to 'This is memo'. Set max supply to 10.",
+        };
+
+        const langchainAgent = await LangchainAgent.create();
+
+        console.log(`Prompt: ${prompt.text}`);
+        console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+        const executorAccountDetails: ExecutorAccountDetails = {
+            executorAccountId: txExecutorAccount.accountId,
+            executorPublicKey: txExecutorAccount.publicKey,
+        }
+
+        // STEP 1: send non-custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+        // STEP 2: extract tx bytes
+        const txBytesString = extractTxBytes(response.messages)
+
+        // STEP 3: verify correctness by signing and executing the tx
+        const executedTx = await signAndExecuteTx(
+          txBytesString,
+          txExecutorAccount.privateKey,
+          txExecutorAccount.accountId
+        )
+
+        await wait(5000); // wait for tx to be executed
+
+        // STEP 4: verify that the token was created correctly
+        const tokenId = await hederaApiClient.getTransactionDetails(
+          formatTxHash(executedTx.txHash),
+        ).then((tx) => tx.entity_id);
+
+        const tokenDetails = await hederaApiClient.getTokenDetails(tokenId);
+
+        expect(tokenDetails.symbol).toEqual("TT");
+        expect(tokenDetails.name).toEqual("TestToken");
+        expect(tokenDetails.type).toEqual(TokenType.NonFungibleUnique.toString());
+        expect(Number(tokenDetails.max_supply)).toEqual(10);
+        expect(tokenDetails.memo).toEqual("This is memo");
+        expect(tokenDetails.metadata).toEqual("");
+        expect(tokenDetails?.supply_key?.key).toBeTruthy(); // all NFTs have a supply key set by default
+        expect(tokenDetails?.admin_key?.key).toBeFalsy();
+        expect(tokenDetails?.metadata_key?.key).toBeFalsy();
+    });
+
+    it("Create token with minimal parameters plus metadata key", async () => {
+        const prompt = {
+            user: "user",
+            text: "Create non-fungible token with name TestToken, symbol TT. Set metadata key.",
+        };
+
+        const langchainAgent = await LangchainAgent.create();
+
+        console.log(`Prompt: ${prompt.text}`);
+        console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+        const executorAccountDetails: ExecutorAccountDetails = {
+            executorAccountId: txExecutorAccount.accountId,
+            executorPublicKey: txExecutorAccount.publicKey,
+        }
+
+        // STEP 1: send non-custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+        // STEP 2: extract tx bytes
+        const txBytesString = extractTxBytes(response.messages)
+
+        // STEP 3: verify correctness by signing and executing the tx
+        const executedTx = await signAndExecuteTx(
+          txBytesString,
+          txExecutorAccount.privateKey,
+          txExecutorAccount.accountId
+        )
+
+        await wait(5000); // wait for tx to be executed
+
+        // STEP 4: verify that the token was created correctly
+        const tokenId = await hederaApiClient.getTransactionDetails(
+          formatTxHash(executedTx.txHash),
+        ).then((tx) => tx.entity_id);
+
+        const tokenDetails = await hederaApiClient.getTokenDetails(tokenId);
+
+        expect(tokenDetails.symbol).toEqual("TT");
+        expect(tokenDetails.name).toEqual("TestToken");
+        expect(tokenDetails.type).toEqual(TokenType.NonFungibleUnique.toString());
+        expect(Number(tokenDetails.max_supply)).toEqual(INFINITE_SUPPLY);
+        expect(tokenDetails.memo).toEqual("");
+        expect(tokenDetails.metadata).toEqual("");
+        expect(tokenDetails?.supply_key?.key).toBeTruthy(); // all NFTs have a supply key set by default
+        expect(tokenDetails?.admin_key?.key).toBeFalsy();
+        expect(tokenDetails?.metadata_key?.key).toBeTruthy();
+    });
+
+    it("Create token with minimal parameters plus admin key and metadata key and memo and metadata", async () => {
+        const prompt = {
+            user: "user",
+            text: "Create non-fungible token with name TestToken, symbol TT. Set metadata key and admin key. Add memo 'thats memo' and metadata 'thats metadata'.",
+        };
+
+        const langchainAgent = await LangchainAgent.create();
+
+        console.log(`Prompt: ${prompt.text}`);
+        console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+        const executorAccountDetails: ExecutorAccountDetails = {
+            executorAccountId: txExecutorAccount.accountId,
+            executorPublicKey: txExecutorAccount.publicKey,
+        }
+
+        // STEP 1: send non-custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+        // STEP 2: extract tx bytes
+        const txBytesString = extractTxBytes(response.messages)
+
+        // STEP 3: verify correctness by signing and executing the tx
+        const executedTx = await signAndExecuteTx(
+          txBytesString,
+          txExecutorAccount.privateKey,
+          txExecutorAccount.accountId
+        )
+
+        await wait(5000); // wait for tx to be executed
+
+        // STEP 4: verify that the token was created correctly
+        const tokenId = await hederaApiClient.getTransactionDetails(
+          formatTxHash(executedTx.txHash),
+        ).then((tx) => tx.entity_id);
+
+        const tokenDetails = await hederaApiClient.getTokenDetails(tokenId);
+
+        expect(tokenDetails.symbol).toEqual("TT");
+        expect(tokenDetails.name).toEqual("TestToken");
+        expect(tokenDetails.type).toEqual(TokenType.NonFungibleUnique.toString());
+        expect(Number(tokenDetails.max_supply)).toEqual(INFINITE_SUPPLY);
+        expect(tokenDetails.memo).toEqual("thats memo");
+        expect(atob(tokenDetails.metadata!)).toEqual("thats metadata");
+        expect(tokenDetails?.supply_key?.key).toBeTruthy(); // all NFTs have a supply key set by default
+        expect(tokenDetails?.admin_key?.key).toBeTruthy();
+        expect(tokenDetails?.metadata_key?.key).toBeTruthy();
+    });
+});

--- a/src/tests/non-custodial/create_nft_token.test.ts
+++ b/src/tests/non-custodial/create_nft_token.test.ts
@@ -36,7 +36,6 @@ describe("create_nft_token", () => {
           autoAssociation
         );
 
-        await wait(3000); // wait for the account to be created
     });
 
     it("Create NFT token with all possible parameters", async () => {
@@ -68,7 +67,7 @@ describe("create_nft_token", () => {
           txExecutorAccount.accountId
         )
 
-        await wait(5000); // wait for tx to be executed
+        await wait(5000); // wait for the mirror node to update
 
         // STEP 4: verify that the token was created correctly
         const tokenId = await hederaApiClient.getTransactionDetails(
@@ -119,7 +118,7 @@ describe("create_nft_token", () => {
           txExecutorAccount.accountId
         )
 
-        await wait(5000); // wait for tx to be executed
+        await wait(5000); // wait for the mirror node to update
 
         // STEP 4: verify that the token was created correctly
         const tokenId = await hederaApiClient.getTransactionDetails(
@@ -170,7 +169,7 @@ describe("create_nft_token", () => {
           txExecutorAccount.accountId
         )
 
-        await wait(5000); // wait for tx to be executed
+        await wait(5000); // wait for the mirror node to update
 
         // STEP 4: verify that the token was created correctly
         const tokenId = await hederaApiClient.getTransactionDetails(
@@ -219,7 +218,7 @@ describe("create_nft_token", () => {
           txExecutorAccount.accountId
         )
 
-        await wait(5000); // wait for tx to be executed
+        await wait(5000); // wait for the mirror node to update
 
         // STEP 4: verify that the token was created correctly
         const tokenId = await hederaApiClient.getTransactionDetails(
@@ -268,7 +267,7 @@ describe("create_nft_token", () => {
           txExecutorAccount.accountId
         )
 
-        await wait(5000); // wait for tx to be executed
+        await wait(5000); // wait for the mirror node to update
 
         // STEP 4: verify that the token was created correctly
         const tokenId = await hederaApiClient.getTransactionDetails(
@@ -317,7 +316,7 @@ describe("create_nft_token", () => {
           txExecutorAccount.accountId
         )
 
-        await wait(5000); // wait for tx to be executed
+        await wait(5000); // wait for the mirror node to update
 
         // STEP 4: verify that the token was created correctly
         const tokenId = await hederaApiClient.getTransactionDetails(

--- a/src/tests/non-custodial/create_nft_token.test.ts
+++ b/src/tests/non-custodial/create_nft_token.test.ts
@@ -35,6 +35,8 @@ describe("create_nft_token", () => {
           startingHbars,
           autoAssociation
         );
+
+        await wait(3000); // wait for the account to be created
     });
 
     it("Create NFT token with all possible parameters", async () => {

--- a/src/tests/non-custodial/create_topic.test.ts
+++ b/src/tests/non-custodial/create_topic.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import * as dotenv from "dotenv";
+import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
+import { LangchainAgent } from "../utils/langchainAgent";
+import { extractTxBytes, formatTxHash, signAndExecuteTx, wait } from "../utils/utils";
+import { NetworkClientWrapper } from "../utils/testnetClient";
+import { AccountData } from "../utils/testnetUtils";
+import { ExecutorAccountDetails } from "../../types";
+
+const IS_CUSTODIAL = false;
+
+dotenv.config();
+describe("create_topic", () => {
+  let hederaApiClient: HederaMirrorNodeClient;
+  let networkClientWrapper: NetworkClientWrapper;
+  let txExecutorAccount: AccountData;
+
+  beforeAll(async () => {
+    hederaApiClient = new HederaMirrorNodeClient("testnet");
+
+    networkClientWrapper = new NetworkClientWrapper(
+      process.env.HEDERA_ACCOUNT_ID!,
+      process.env.HEDERA_PRIVATE_KEY!,
+      process.env.HEDERA_KEY_TYPE!,
+      "testnet"
+    );
+
+    // Create test account
+    const startingHbars = 5;
+    const autoAssociation = -1; // unlimited auto association
+    txExecutorAccount = await networkClientWrapper.createAccount(
+      startingHbars,
+      autoAssociation
+    );
+
+  })
+
+  describe("create_topic", () => {
+    it("should create topic", async () => {
+      const MEMO = "Hello world";
+      const prompt = {
+        user: "user",
+        text: `Create a topic with memo "${MEMO}"`,
+      };
+
+      const langchainAgent = await LangchainAgent.create();
+
+      console.log(`Prompt: ${prompt.text}`);
+      console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+      const executorAccountDetails: ExecutorAccountDetails = {
+        executorAccountId: txExecutorAccount.accountId,
+        executorPublicKey: txExecutorAccount.publicKey,
+      }
+
+      // STEP 1: send non-custodial prompt
+      const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+      // STEP 2: extract tx bytes
+      const txBytesString = extractTxBytes(response.messages)
+
+      // STEP 3: verify correctness by signing and executing the tx
+      const executedTx = await signAndExecuteTx(
+        txBytesString,
+        txExecutorAccount.privateKey,
+        txExecutorAccount.accountId
+      )
+
+      await wait(5000); // wait for tx to be executed
+
+      // STEP 4: verify that the topic was created correctly
+      const topicId = await hederaApiClient.getTransactionDetails(
+        formatTxHash(executedTx.txHash),
+      ).then((tx) => tx.entity_id);
+
+      const topic = await hederaApiClient.getTopic(topicId);
+
+      expect(topic.memo).toEqual(MEMO);
+      expect(!!topic.submit_key).toBeFalsy();
+    });
+
+    it("should create topic with submit key", async () => {
+      const MEMO = "Hello world";
+      const prompt = {
+        user: "user",
+        text: `Create a topic with memo "${MEMO}". Restrict posting with a key`,
+      };
+
+      const langchainAgent = await LangchainAgent.create();
+
+      console.log(`Prompt: ${prompt.text}`);
+      console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+      const executorAccountDetails: ExecutorAccountDetails = {
+        executorAccountId: txExecutorAccount.accountId,
+        executorPublicKey: txExecutorAccount.publicKey,
+      }
+
+      // STEP 1: send non-custodial prompt
+      const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+      // STEP 2: extract tx bytes
+      const txBytesString = extractTxBytes(response.messages)
+
+      // STEP 3: verify correctness by signing and executing the tx
+      const executedTx = await signAndExecuteTx(
+        txBytesString,
+        txExecutorAccount.privateKey,
+        txExecutorAccount.accountId
+      )
+
+      await wait(5000); // wait for tx to be executed
+
+      // STEP 4: verify that the topic was created correctly
+      const topicId = await hederaApiClient.getTransactionDetails(
+        formatTxHash(executedTx.txHash),
+      ).then((tx) => tx.entity_id);
+
+      const topic = await hederaApiClient.getTopic(topicId);
+
+      expect(topic.memo).toEqual(MEMO);
+      expect(!!topic.submit_key).toBeTruthy();
+    });
+
+    it("should create topic without submit key", async () => {
+      const MEMO = "Hello world";
+      const prompt = {
+        user: "user",
+        text: `Create a topic with memo "${MEMO}". Do not set a submit key`,
+      };
+
+      const langchainAgent = await LangchainAgent.create();
+
+      console.log(`Prompt: ${prompt.text}`);
+      console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+      const executorAccountDetails: ExecutorAccountDetails = {
+        executorAccountId: txExecutorAccount.accountId,
+        executorPublicKey: txExecutorAccount.publicKey,
+      }
+
+      // STEP 1: send non-custodial prompt
+      const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+      // STEP 2: extract tx bytes
+      const txBytesString = extractTxBytes(response.messages)
+
+      // STEP 3: verify correctness by signing and executing the tx
+      const executedTx = await signAndExecuteTx(
+        txBytesString,
+        txExecutorAccount.privateKey,
+        txExecutorAccount.accountId
+      )
+
+      await wait(5000); // wait for tx to be executed
+
+      // STEP 4: verify that the topic was created correctly
+      const topicId = await hederaApiClient.getTransactionDetails(
+        formatTxHash(executedTx.txHash),
+      ).then((tx) => tx.entity_id);
+
+      const topic = await hederaApiClient.getTopic(topicId);
+
+      expect(topic.memo).toEqual(MEMO);
+      expect(!!topic.submit_key).toBeFalsy();
+    });
+
+    afterEach(() => {
+      console.log("\n\n");
+    })
+  });
+});

--- a/src/tests/non-custodial/create_topic.test.ts
+++ b/src/tests/non-custodial/create_topic.test.ts
@@ -25,7 +25,7 @@ describe("create_topic", () => {
       "testnet"
     );
 
-    // Create test account
+    // Create a test account
     const startingHbars = 5;
     const autoAssociation = -1; // unlimited auto association
     txExecutorAccount = await networkClientWrapper.createAccount(
@@ -33,6 +33,7 @@ describe("create_topic", () => {
       autoAssociation
     );
 
+    await wait(3000); // wait for the account to be created
   })
 
   describe("create_topic", () => {

--- a/src/tests/non-custodial/create_topic.test.ts
+++ b/src/tests/non-custodial/create_topic.test.ts
@@ -32,8 +32,6 @@ describe("create_topic", () => {
       startingHbars,
       autoAssociation
     );
-
-    await wait(3000); // wait for the account to be created
   })
 
   describe("create_topic", () => {
@@ -67,7 +65,7 @@ describe("create_topic", () => {
         txExecutorAccount.accountId
       )
 
-      await wait(5000); // wait for tx to be executed
+      await wait(5000); // wait for the mirror node to update
 
       // STEP 4: verify that the topic was created correctly
       const topicId = await hederaApiClient.getTransactionDetails(
@@ -110,7 +108,7 @@ describe("create_topic", () => {
         txExecutorAccount.accountId
       )
 
-      await wait(5000); // wait for tx to be executed
+      await wait(5000); // wait for the mirror node to update
 
       // STEP 4: verify that the topic was created correctly
       const topicId = await hederaApiClient.getTransactionDetails(
@@ -153,7 +151,7 @@ describe("create_topic", () => {
         txExecutorAccount.accountId
       )
 
-      await wait(5000); // wait for tx to be executed
+      await wait(5000); // wait for the mirror node to update
 
       // STEP 4: verify that the topic was created correctly
       const topicId = await hederaApiClient.getTransactionDetails(

--- a/src/tests/non-custodial/delete_topic.test.ts
+++ b/src/tests/non-custodial/delete_topic.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeAll, afterEach } from "vitest";
+import { describe, expect, it, beforeAll } from "vitest";
 import * as dotenv from "dotenv";
 import { NetworkClientWrapper } from "../utils/testnetClient";
 import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";

--- a/src/tests/non-custodial/delete_topic.test.ts
+++ b/src/tests/non-custodial/delete_topic.test.ts
@@ -39,6 +39,8 @@ describe("delete_topic", () => {
         autoAssociation
       );
 
+      await wait(3000); // wait for the account to be created
+
       // a custodial client wrapper for the tx executor account is required for creating topics before the test
       executorCustodialClientWrapper = new NetworkClientWrapper(
         txExecutorAccount.accountId,
@@ -56,6 +58,8 @@ describe("delete_topic", () => {
         topic2 = _topic2.topicId;
         topic3 = _topic3.topicId;
       });
+
+      await wait(3000); // wait for the topics to be created
 
       testCases = [
         {

--- a/src/tests/non-custodial/delete_topic.test.ts
+++ b/src/tests/non-custodial/delete_topic.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, beforeAll, afterEach } from "vitest";
+import * as dotenv from "dotenv";
+import { NetworkClientWrapper } from "../utils/testnetClient";
+import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
+import { LangchainAgent } from "../utils/langchainAgent";
+import { extractTxBytes, signAndExecuteTx, wait } from "../utils/utils";
+import { AccountData } from "../utils/testnetUtils";
+import { ExecutorAccountDetails } from "../../types";
+
+const IS_CUSTODIAL = false;
+
+dotenv.config();
+describe("delete_topic", () => {
+  let topic1: string;
+  let topic2: string;
+  let topic3: string;
+  let testCases: { promptText: string; topicId: string }[];
+  let networkClientWrapper: NetworkClientWrapper;
+  let executorCustodialClientWrapper: NetworkClientWrapper;
+  let txExecutorAccount: AccountData;
+  let hederaApiClient: HederaMirrorNodeClient;
+
+  beforeAll(async () => {
+    try {
+      hederaApiClient = new HederaMirrorNodeClient("testnet");
+
+      networkClientWrapper = new NetworkClientWrapper(
+        process.env.HEDERA_ACCOUNT_ID!,
+        process.env.HEDERA_PRIVATE_KEY!,
+        process.env.HEDERA_KEY_TYPE!,
+        "testnet"
+      );
+
+      // Create a test account
+      const startingHbars = 60;
+      const autoAssociation = -1; // unlimited auto association
+      txExecutorAccount = await networkClientWrapper.createAccount(
+        startingHbars,
+        autoAssociation
+      );
+
+      // a custodial client wrapper for the tx executor account is required for creating topics before the test
+      executorCustodialClientWrapper = new NetworkClientWrapper(
+        txExecutorAccount.accountId,
+        txExecutorAccount.privateKey,
+        'ECDSA', // .createAccount() creates account with ECDSA key
+        "testnet"
+      );
+
+      await Promise.all([
+        executorCustodialClientWrapper.createTopic("Hello world 1", true),
+        executorCustodialClientWrapper.createTopic("Hello world 2", true),
+        executorCustodialClientWrapper.createTopic("Hello world 3", true),
+      ]).then(([_topic1, _topic2, _topic3]) => {
+        topic1 = _topic1.topicId;
+        topic2 = _topic2.topicId;
+        topic3 = _topic3.topicId;
+      });
+
+      testCases = [
+        {
+          promptText: `Delete topic with id ${topic1}`,
+          topicId: topic1,
+        },
+        {
+          promptText: `Delete topic with id ${topic2}`,
+          topicId: topic2,
+        },
+        {
+          promptText: `Delete topic with id ${topic3}`,
+          topicId: topic3,
+        },
+      ];
+    } catch (error) {
+      console.error("Error in setup:", error);
+      throw error;
+    }
+  });
+
+  describe("delete topic checks", () => {
+    it("should delete topic", async () => {
+      for (const { promptText, topicId } of testCases) {
+        const prompt = {
+          user: "user",
+          text: promptText,
+        };
+
+        const langchainAgent = await LangchainAgent.create();
+
+        console.log(`Prompt: ${promptText}`);
+        console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+        const executorAccountDetails: ExecutorAccountDetails = {
+          executorAccountId: txExecutorAccount.accountId,
+          executorPublicKey: txExecutorAccount.publicKey,
+        }
+
+        // STEP 1: send non-custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+        // STEP 2: extract tx bytes
+        const txBytesString = extractTxBytes(response.messages)
+
+        // STEP 3: verify correctness by signing and executing the tx
+        const executedTx = await signAndExecuteTx(
+          txBytesString,
+          txExecutorAccount.privateKey,
+          txExecutorAccount.accountId
+        )
+
+        await wait(5000); // wait for tx to be executed
+
+        // STEP 4: verify that the topic was deleted correctly
+        const topicInfo = await hederaApiClient.getTopic(topicId);
+
+        expect(topicInfo.deleted).toBe(true);
+      }
+    });
+  });
+
+  afterEach(() => {
+    console.log("\n\n");
+  })
+});

--- a/src/tests/non-custodial/delete_topic.test.ts
+++ b/src/tests/non-custodial/delete_topic.test.ts
@@ -114,11 +114,9 @@ describe("delete_topic", () => {
         const topicInfo = await hederaApiClient.getTopic(topicId);
 
         expect(topicInfo.deleted).toBe(true);
+
+        console.log("\n\n");
       }
     });
   });
-
-  afterEach(() => {
-    console.log("\n\n");
-  })
 });

--- a/src/tests/non-custodial/delete_topic.test.ts
+++ b/src/tests/non-custodial/delete_topic.test.ts
@@ -39,8 +39,6 @@ describe("delete_topic", () => {
         autoAssociation
       );
 
-      await wait(3000); // wait for the account to be created
-
       // a custodial client wrapper for the tx executor account is required for creating topics before the test
       executorCustodialClientWrapper = new NetworkClientWrapper(
         txExecutorAccount.accountId,
@@ -58,8 +56,6 @@ describe("delete_topic", () => {
         topic2 = _topic2.topicId;
         topic3 = _topic3.topicId;
       });
-
-      await wait(3000); // wait for the topics to be created
 
       testCases = [
         {
@@ -112,7 +108,7 @@ describe("delete_topic", () => {
           txExecutorAccount.accountId
         )
 
-        await wait(5000); // wait for tx to be executed
+        await wait(5000); // wait for the mirror node to update
 
         // STEP 4: verify that the topic was deleted correctly
         const topicInfo = await hederaApiClient.getTopic(topicId);

--- a/src/tests/non-custodial/dissociate_token.test.ts
+++ b/src/tests/non-custodial/dissociate_token.test.ts
@@ -45,6 +45,8 @@ describe("dissociate_token (non-custodial)", () => {
         0 // no auto association
       );
 
+      await wait(3000); // wait for accounts to be created
+
       const tokenCreatorAccountNetworkClientWrapper =
         new NetworkClientWrapper(
           tokenCreatorAccount.accountId,
@@ -81,13 +83,13 @@ describe("dissociate_token (non-custodial)", () => {
         token2 = _token2;
       });
 
-      await wait(3000);
+      await wait(3000); // wait for tokens to be created
 
       // associate with those tokens
       await executorCustodialAccountNetworkClientWrapper.associateToken(token1);
       await executorCustodialAccountNetworkClientWrapper.associateToken(token2);
 
-      await wait(3000);
+      await wait(3000); // wait for tokens to be associated
 
       testCases = [
         {
@@ -136,7 +138,7 @@ describe("dissociate_token (non-custodial)", () => {
           txExecutorAccount.accountId
         )
 
-        await wait(5000); // wait for tx to be executed
+        await wait(3000); // wait for tx to be executed
 
         // STEP 2: verify correctness by checking that token was dissociated
         const token = await hederaApiClient.getAccountToken(

--- a/src/tests/non-custodial/dissociate_token.test.ts
+++ b/src/tests/non-custodial/dissociate_token.test.ts
@@ -45,8 +45,6 @@ describe("dissociate_token (non-custodial)", () => {
         0 // no auto association
       );
 
-      await wait(3000); // wait for accounts to be created
-
       const tokenCreatorAccountNetworkClientWrapper =
         new NetworkClientWrapper(
           tokenCreatorAccount.accountId,
@@ -83,13 +81,9 @@ describe("dissociate_token (non-custodial)", () => {
         token2 = _token2;
       });
 
-      await wait(3000); // wait for tokens to be created
-
       // associate with those tokens
       await executorCustodialAccountNetworkClientWrapper.associateToken(token1);
       await executorCustodialAccountNetworkClientWrapper.associateToken(token2);
-
-      await wait(3000); // wait for tokens to be associated
 
       testCases = [
         {
@@ -138,7 +132,7 @@ describe("dissociate_token (non-custodial)", () => {
           txExecutorAccount.accountId
         )
 
-        await wait(3000); // wait for tx to be executed
+        await wait(5000); // wait for the mirror node to update
 
         // STEP 2: verify correctness by checking that token was dissociated
         const token = await hederaApiClient.getAccountToken(

--- a/src/tests/non-custodial/dissociate_token.test.ts
+++ b/src/tests/non-custodial/dissociate_token.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import * as dotenv from "dotenv";
+import { NetworkClientWrapper } from "../utils/testnetClient";
+import { AccountData } from "../utils/testnetUtils";
+import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
+import { LangchainAgent } from "../utils/langchainAgent";
+import { NetworkType } from "../types";
+import { extractTxBytes, signAndExecuteTx, wait } from "../utils/utils";
+import { ExecutorAccountDetails } from "../../types";
+
+const IS_CUSTODIAL = false;
+
+dotenv.config();
+describe("dissociate_token (non-custodial)", () => {
+  let tokenCreatorAccount: AccountData;
+  let token1: string;
+  let token2: string;
+  let networkClientWrapper: NetworkClientWrapper;
+  let testCases: {
+    tokenToDissociateId: string;
+    promptText: string;
+  }[];
+  let txExecutorAccount: AccountData;
+  let hederaApiClient: HederaMirrorNodeClient;
+
+  beforeAll(async () => {
+    try {
+      hederaApiClient = new HederaMirrorNodeClient("testnet" as NetworkType);
+
+      networkClientWrapper = new NetworkClientWrapper(
+        process.env.HEDERA_ACCOUNT_ID!,
+        process.env.HEDERA_PRIVATE_KEY!,
+        process.env.HEDERA_KEY_TYPE!,
+        "testnet"
+      );
+
+      // Create test accounts
+      tokenCreatorAccount = await networkClientWrapper.createAccount(
+        20, // starting HBARs
+        0 // no auto association
+      );
+
+      txExecutorAccount = await networkClientWrapper.createAccount(
+        5, // starting HBARs
+        0 // no auto association
+      );
+
+      const tokenCreatorAccountNetworkClientWrapper =
+        new NetworkClientWrapper(
+          tokenCreatorAccount.accountId,
+          tokenCreatorAccount.privateKey,
+          "ECDSA",
+          "testnet"
+        );
+
+      // custodial executor network client wrapper is required for associating tokens that will be dissociated in non-custodial flow
+      const executorCustodialAccountNetworkClientWrapper =
+        new NetworkClientWrapper(
+          txExecutorAccount.accountId,
+          txExecutorAccount.privateKey,
+          "ECDSA",
+          "testnet"
+        );
+
+      // create tokens
+      await Promise.all([
+        tokenCreatorAccountNetworkClientWrapper.createFT({
+          name: "TokenToDissociate1",
+          symbol: "TTD1",
+          initialSupply: 1000,
+          decimals: 2,
+        }),
+        tokenCreatorAccountNetworkClientWrapper.createFT({
+          name: "TokenToDissociate2",
+          symbol: "TTD2",
+          initialSupply: 1000,
+          decimals: 2,
+        }),
+      ]).then(([_token1, _token2]) => {
+        token1 = _token1;
+        token2 = _token2;
+      });
+
+      await wait(3000);
+
+      // associate with those tokens
+      await executorCustodialAccountNetworkClientWrapper.associateToken(token1);
+      await executorCustodialAccountNetworkClientWrapper.associateToken(token2);
+
+      await wait(3000);
+
+      testCases = [
+        {
+          tokenToDissociateId: token1,
+          promptText: `Dissociate token ${token1} from my account`,
+        },
+        {
+          tokenToDissociateId: token2,
+          promptText: `Dissociate token ${token2} from my account`,
+        },
+      ];
+    } catch (error) {
+      console.error("Error in setup:", error);
+      throw error;
+    }
+  });
+
+  describe("dissociate token checks", () => {
+    it("should dissociate token", async () => {
+      for (const { promptText, tokenToDissociateId } of testCases || []) {
+        const prompt = {
+          user: "user",
+          text: promptText,
+        };
+
+        const langchainAgent = await LangchainAgent.create();
+
+        console.log(`Prompt: ${promptText}`);
+        console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+        const executorAccountDetails: ExecutorAccountDetails = {
+          executorAccountId: txExecutorAccount.accountId,
+          executorPublicKey: txExecutorAccount.publicKey,
+        }
+
+        // STEP 1: send non-custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+        // STEP 2: extract tx bytes
+        const txBytesString = extractTxBytes(response.messages)
+
+        // STEP 3: verify correctness by signing and executing the tx
+        const executedTx = await signAndExecuteTx(
+          txBytesString,
+          txExecutorAccount.privateKey,
+          txExecutorAccount.accountId
+        )
+
+        await wait(5000); // wait for tx to be executed
+
+        // STEP 2: verify correctness by checking that token was dissociated
+        const token = await hederaApiClient.getAccountToken(
+          networkClientWrapper.getAccountId(),
+          tokenToDissociateId
+        );
+
+        expect(token).toBeUndefined();
+
+        console.log('\n\n');
+      }
+    });
+  });
+});

--- a/src/tests/non-custodial/get_all_balances.test.ts
+++ b/src/tests/non-custodial/get_all_balances.test.ts
@@ -1,0 +1,181 @@
+import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
+import { describe, expect, it, beforeAll } from "vitest";
+import * as dotenv from "dotenv";
+import { NetworkClientWrapper } from "../utils/testnetClient";
+import { AccountData } from "../utils/testnetUtils";
+import { DetailedTokenBalance } from "../types";
+import { LangchainAgent } from "../utils/langchainAgent";
+import { wait } from "../utils/utils";
+import { ExecutorAccountDetails } from "../../types";
+
+const IS_CUSTODIAL = false;
+
+const extractBalances = (messages: any[]): DetailedTokenBalance[] => {
+  const result = messages.reduce((acc, { content }) => {
+    try {
+      const response = JSON.parse(content);
+      console.log(response);
+      if (response.status === "error") {
+        throw new Error(response.message);
+      }
+
+      if (!response?.balances) {
+        throw new Error("Balance not found");
+      }
+      return response.balances as DetailedTokenBalance[];
+    } catch {
+      return acc;
+    }
+  }, "");
+
+  if (!Array.isArray(result)) {
+    throw new Error("No balances");
+  }
+
+  return result;
+};
+
+describe("get_all_balances (non-custodial)", () => {
+  let acc1: AccountData;
+  let acc2: AccountData;
+  let acc3: AccountData;
+  let txExecutorAccount: AccountData;
+  let token1: string;
+  let token2: string;
+  let hederaApiClient: HederaMirrorNodeClient;
+  let testCases: [string, string][];
+
+  beforeAll(async () => {
+    dotenv.config();
+    try {    
+      const networkClientWrapper = new NetworkClientWrapper(
+        process.env.HEDERA_ACCOUNT_ID!,
+        process.env.HEDERA_PRIVATE_KEY!,
+        process.env.HEDERA_KEY_TYPE!,
+        "testnet"
+      );
+
+      // Create accounts
+      await Promise.all([
+        networkClientWrapper.createAccount(0, -1),
+        networkClientWrapper.createAccount(0, -1),
+        networkClientWrapper.createAccount(0, -1),
+        networkClientWrapper.createAccount(0, -1),
+      ]).then(([_acc1, _acc2, _acc3, _acc4]) => {
+        acc1 = _acc1;
+        acc2 = _acc2;
+        acc3 = _acc3;
+        txExecutorAccount = _acc4;
+      });
+      
+
+      // Create tokens
+      await Promise.all([
+        networkClientWrapper.createFT({
+          name: "MyToken",
+          symbol: "MTK",
+          initialSupply: 1000,
+          decimals: 2,
+        }),
+        networkClientWrapper.createFT({
+          name: "MyToken2",
+          symbol: "MTK2",
+          initialSupply: 2000,
+          decimals: 0,
+        }),
+      ]).then(([_token1, _token2]) => {
+        token1 = _token1;
+        token2 = _token2;
+      });
+
+      // Transfer tokens to accounts
+      await Promise.all([ 
+        networkClientWrapper.transferToken(acc1.accountId, token1, 100),
+        networkClientWrapper.transferToken(acc2.accountId, token2, 123),
+        networkClientWrapper.transferToken(acc3.accountId, token2, 10),
+        networkClientWrapper.transferToken(acc3.accountId, token1, 7),
+        networkClientWrapper.transferToken(txExecutorAccount.accountId, token1, 17),
+      ]);
+
+      await wait(5000);
+      hederaApiClient = new HederaMirrorNodeClient("testnet");
+
+      testCases = [
+        [
+          acc1.accountId,
+          `Show me the balances of all tokens for wallet ${acc1.accountId}`,
+        ],
+        [
+          acc2.accountId,
+          `What are the token balances for wallet ${acc2.accountId}`,
+        ],
+        [
+          acc3.accountId,
+          `Show me all token balances for account ${acc3.accountId}`,
+        ],
+        [txExecutorAccount.accountId, "Show me all your token balances."],
+        [txExecutorAccount.accountId, "Show me all my token balances."],
+      ];
+    } catch (error) {
+      console.error("Error in setup:", error);
+      throw error;
+    }
+  });
+
+  /*
+  This action is not a typical non-custodial action. It does not require creation of any transaction, therefore no txBytes are returned.
+  This action fetches data from the hedera mirror node and returns the balances of all tokens for the given account.
+  If no account is provided, the Executor account is used by default in non-custodial flow, whereas in custodial flow, the operator account is used.
+   */
+  describe("balance checks", () => {
+    it("should test all token balances", async () => {
+      for (const [accountId, promptText] of testCases) {
+        const prompt = {
+          user: "user",
+          text: promptText,
+        };
+        const langchainAgent = await LangchainAgent.create();
+
+        console.log(`Prompt: ${promptText}`);
+        console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+        const executorAccountDetails: ExecutorAccountDetails = {
+          executorAccountId: txExecutorAccount.accountId,
+          executorPublicKey: txExecutorAccount.publicKey,
+        }
+
+        // STEP 1: send non-custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+        // STEP 2: extract balances
+        const tokensBalanceFromLangchain = extractBalances(response.messages);
+
+        // STEP 3: verify with balances from hedera mirror node
+        const allTokensBalances =
+          await hederaApiClient.getAllTokensBalances(accountId);
+
+        const formattedBalances = allTokensBalances.map((token) => ({
+          ...token,
+          balanceInDisplayUnit: token.balanceInDisplayUnit.toString(),
+        }));
+
+        formattedBalances.forEach((token) => {
+          const correspondingTokenFromLangchain = tokensBalanceFromLangchain.find(
+            ({ tokenId: elizaTokenId }) => elizaTokenId === token.tokenId
+          );
+          expect(correspondingTokenFromLangchain?.tokenId).toEqual(token.tokenId);
+          expect(correspondingTokenFromLangchain?.balance).toEqual(token.balance);
+          expect(correspondingTokenFromLangchain?.tokenName).toEqual(
+            token.tokenName
+          );
+          expect(correspondingTokenFromLangchain?.tokenSymbol).toEqual(
+            token.tokenSymbol
+          );
+        });
+
+        await wait(1000);
+        console.log("\n\n");
+      }
+    });
+  });
+});

--- a/src/tests/non-custodial/get_all_balances.test.ts
+++ b/src/tests/non-custodial/get_all_balances.test.ts
@@ -68,8 +68,6 @@ describe("get_all_balances (non-custodial)", () => {
         txExecutorAccount = _acc4;
       });
 
-      await wait(3000); // wait for accounts to be created
-
       // Create tokens
       await Promise.all([
         networkClientWrapper.createFT({
@@ -89,8 +87,6 @@ describe("get_all_balances (non-custodial)", () => {
         token2 = _token2;
       });
 
-      await wait(3000); // wait for tokens to be created
-
       // Transfer tokens to accounts
       await Promise.all([ 
         networkClientWrapper.transferToken(acc1.accountId, token1, 100),
@@ -99,8 +95,6 @@ describe("get_all_balances (non-custodial)", () => {
         networkClientWrapper.transferToken(acc3.accountId, token1, 7),
         networkClientWrapper.transferToken(txExecutorAccount.accountId, token1, 17),
       ]);
-
-      await wait(3000); // wait for tokens to be created and transferred to accounts
 
       hederaApiClient = new HederaMirrorNodeClient("testnet");
 
@@ -177,7 +171,6 @@ describe("get_all_balances (non-custodial)", () => {
           );
         });
 
-        await wait(1000);
         console.log("\n\n");
       }
     });

--- a/src/tests/non-custodial/get_all_balances.test.ts
+++ b/src/tests/non-custodial/get_all_balances.test.ts
@@ -67,7 +67,8 @@ describe("get_all_balances (non-custodial)", () => {
         acc3 = _acc3;
         txExecutorAccount = _acc4;
       });
-      
+
+      await wait(3000); // wait for accounts to be created
 
       // Create tokens
       await Promise.all([
@@ -88,6 +89,8 @@ describe("get_all_balances (non-custodial)", () => {
         token2 = _token2;
       });
 
+      await wait(3000); // wait for tokens to be created
+
       // Transfer tokens to accounts
       await Promise.all([ 
         networkClientWrapper.transferToken(acc1.accountId, token1, 100),
@@ -97,7 +100,8 @@ describe("get_all_balances (non-custodial)", () => {
         networkClientWrapper.transferToken(txExecutorAccount.accountId, token1, 17),
       ]);
 
-      await wait(5000);
+      await wait(3000); // wait for tokens to be created and transferred to accounts
+
       hederaApiClient = new HederaMirrorNodeClient("testnet");
 
       testCases = [

--- a/src/tests/non-custodial/get_hbar_balance.test.ts
+++ b/src/tests/non-custodial/get_hbar_balance.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, beforeAll, afterEach } from "vitest";
+import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
+import * as dotenv from "dotenv";
+import { NetworkClientWrapper } from "../utils/testnetClient";
+import { AccountData } from "../utils/testnetUtils";
+import { LangchainAgent } from "../utils/langchainAgent";
+import { wait } from "../utils/utils";
+import { ExecutorAccountDetails } from "../../types";
+
+const IS_CUSTODIAL = false;
+
+describe("get_hbar_balance", () => {
+  let acc1: AccountData;
+  let acc2: AccountData;
+  let acc3: AccountData;
+  let langchainAgent: LangchainAgent;
+  let hederaApiClient: HederaMirrorNodeClient;
+  let testCases: [string, string][];
+  let txExecutorAccount: AccountData;
+
+  beforeAll(async () => {
+    dotenv.config();
+    try {
+      const networkClientWrapper = new NetworkClientWrapper(
+        process.env.HEDERA_ACCOUNT_ID!,
+        process.env.HEDERA_PRIVATE_KEY!,
+        process.env.HEDERA_KEY_TYPE!,
+        "testnet"
+      );
+      // Create a test account
+      acc1 = await networkClientWrapper.createAccount(1);
+      acc2 = await networkClientWrapper.createAccount(0.3);
+      acc3 = await networkClientWrapper.createAccount(0);
+
+      const startingHbars = 1.23;
+      const autoAssociation = -1; // unlimited auto association
+      txExecutorAccount = await networkClientWrapper.createAccount(
+        startingHbars,
+        autoAssociation
+      );
+
+      hederaApiClient = new HederaMirrorNodeClient(
+        process.env.HEDERA_NETWORK_TYPE as "testnet" | "mainnet" | "previewnet"
+      );
+      testCases = [
+        [acc1.accountId, `What's HBAR balance for ${acc1.accountId}`],
+        [acc2.accountId, `How much HBARs has ${acc2.accountId}`],
+        [acc3.accountId, `Check HBAR balance of wallet ${acc3.accountId}`],
+        [txExecutorAccount.accountId, `What's my HBAR balance?`],
+      ];
+    } catch (error) {
+      console.error("Error in setup:", error);
+      throw error;
+    }
+  });
+
+  describe("balance checks", () => {
+    it("should test dynamic account balances", async () => {
+      for (const [accountId, promptText] of testCases) {
+        const prompt = {
+          user: "user",
+          text: promptText,
+        };
+
+        langchainAgent = await LangchainAgent.create();
+
+        console.log(`Prompt: ${promptText}`);
+        console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+        const executorAccountDetails: ExecutorAccountDetails = {
+          executorAccountId: txExecutorAccount.accountId,
+          executorPublicKey: txExecutorAccount.publicKey,
+        }
+
+        // STEP 1: send non-custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+        let hederaActionBalance: number;
+
+        // STEP 2: extract response data (this action fetches data from the mirror node, so there is no transaction to sign and execute)')
+        const match = response.messages[
+          response.messages.length - 1
+        ].text.match(/(\d+\.\d+|\d+)\s*HBAR/);
+
+        if (match) {
+          hederaActionBalance = parseFloat(match[1]);
+        } else {
+          throw new Error(
+            "No match for HBAR balance found in response."
+          );
+        }
+        // STEP 3: verify correctness by comparing the retrieved balance with the one from the mirror node
+        const accountInfo = await hederaApiClient.getAccountInfo(accountId);
+        const accountBalanceInBaseUnits = accountInfo.balance.balance;
+        const mirrorNodeBalanceInDisplayUnits =
+          await hederaApiClient.getHbarBalance(accountId);
+
+        const HBAR_DECIMALS = 8;
+        // compare balance in display units
+        expect(hederaActionBalance).toEqual(mirrorNodeBalanceInDisplayUnits);
+        // compare balance in base units
+        expect(hederaActionBalance * 10 ** HBAR_DECIMALS).toEqual(accountBalanceInBaseUnits);
+
+        await wait(1000);
+      }
+    });
+
+    afterEach(() => {
+      console.log('\n\n');
+    })
+
+  });
+});

--- a/src/tests/non-custodial/get_hbar_balance.test.ts
+++ b/src/tests/non-custodial/get_hbar_balance.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeAll, afterEach } from "vitest";
+import { describe, expect, it, beforeAll } from "vitest";
 import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
 import * as dotenv from "dotenv";
 import { NetworkClientWrapper } from "../utils/testnetClient";

--- a/src/tests/non-custodial/get_hbar_balance.test.ts
+++ b/src/tests/non-custodial/get_hbar_balance.test.ts
@@ -102,12 +102,8 @@ describe("get_hbar_balance", () => {
         expect(hederaActionBalance * 10 ** HBAR_DECIMALS).toEqual(accountBalanceInBaseUnits);
 
         await wait(1000);
+        console.log('\n\n');
       }
     });
-
-    afterEach(() => {
-      console.log('\n\n');
-    })
-
   });
 });

--- a/src/tests/non-custodial/get_hbar_balance.test.ts
+++ b/src/tests/non-custodial/get_hbar_balance.test.ts
@@ -39,9 +39,12 @@ describe("get_hbar_balance", () => {
         autoAssociation
       );
 
+      await wait(3000); // wait for accounts to be created
+
       hederaApiClient = new HederaMirrorNodeClient(
         process.env.HEDERA_NETWORK_TYPE as "testnet" | "mainnet" | "previewnet"
       );
+
       testCases = [
         [acc1.accountId, `What's HBAR balance for ${acc1.accountId}`],
         [acc2.accountId, `How much HBARs has ${acc2.accountId}`],
@@ -101,7 +104,6 @@ describe("get_hbar_balance", () => {
         // compare balance in base units
         expect(hederaActionBalance * 10 ** HBAR_DECIMALS).toEqual(accountBalanceInBaseUnits);
 
-        await wait(1000);
         console.log('\n\n');
       }
     });

--- a/src/tests/non-custodial/get_hbar_balance.test.ts
+++ b/src/tests/non-custodial/get_hbar_balance.test.ts
@@ -4,7 +4,6 @@ import * as dotenv from "dotenv";
 import { NetworkClientWrapper } from "../utils/testnetClient";
 import { AccountData } from "../utils/testnetUtils";
 import { LangchainAgent } from "../utils/langchainAgent";
-import { wait } from "../utils/utils";
 import { ExecutorAccountDetails } from "../../types";
 
 const IS_CUSTODIAL = false;
@@ -38,8 +37,6 @@ describe("get_hbar_balance", () => {
         startingHbars,
         autoAssociation
       );
-
-      await wait(3000); // wait for accounts to be created
 
       hederaApiClient = new HederaMirrorNodeClient(
         process.env.HEDERA_NETWORK_TYPE as "testnet" | "mainnet" | "previewnet"

--- a/src/tests/non-custodial/get_hts_balance.test.ts
+++ b/src/tests/non-custodial/get_hts_balance.test.ts
@@ -58,6 +58,8 @@ describe("get_hts_balance (non-custodial)", () => {
         txExecutorAccount = _acc4;
       });
 
+      await wait(3000); // wait for accounts to be created
+
       // Create tokens
       token1 = await networkClientWrapper.createFT({
         name: "MyToken",
@@ -72,6 +74,8 @@ describe("get_hts_balance (non-custodial)", () => {
         decimals: 0,
       });
 
+      await wait(3000); // wait for tokens to be created
+
       // Transfer tokens to accounts
       await Promise.all([
         networkClientWrapper.transferToken(acc1.accountId, token1, 100),
@@ -80,7 +84,9 @@ describe("get_hts_balance (non-custodial)", () => {
         networkClientWrapper.transferToken(acc3.accountId, token1, 7),
         networkClientWrapper.transferToken(txExecutorAccount.accountId, token2, 17),
       ]);
-      await wait(5000);
+
+      await wait(3000); // wait for transfers to be completed
+
       hederaApiClient = new HederaMirrorNodeClient("testnet");
 
       testCases = [
@@ -153,8 +159,6 @@ describe("get_hts_balance (non-custodial)", () => {
         // STEP 1: send non-custodial prompt
         const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
 
-        await wait(3000);
-
         // STEP 2: extract balance
         const hederaActionBalanceInDisplayUnits = extractTokenBalance(response.messages);
 
@@ -175,7 +179,6 @@ describe("get_hts_balance (non-custodial)", () => {
         expect(String(hederaActionBalanceInDisplayUnits)).toEqual(String(mirrorNodeBalanceInDisplayUnits));
         expect(hederaActionBalanceInBaseUnits).toEqual(String(mirrorNodeBalanceInBaseUnits));
 
-        await wait(3000);
         console.log('\n\n');
       }
     });

--- a/src/tests/non-custodial/get_hts_balance.test.ts
+++ b/src/tests/non-custodial/get_hts_balance.test.ts
@@ -4,7 +4,6 @@ import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
 import * as dotenv from "dotenv";
 import { NetworkClientWrapper } from "../utils/testnetClient";
 import { AccountData } from "../utils/testnetUtils";
-import { wait } from "../utils/utils";
 import { ExecutorAccountDetails } from "../../types";
 
 const IS_CUSTODIAL = false;
@@ -58,8 +57,6 @@ describe("get_hts_balance (non-custodial)", () => {
         txExecutorAccount = _acc4;
       });
 
-      await wait(3000); // wait for accounts to be created
-
       // Create tokens
       token1 = await networkClientWrapper.createFT({
         name: "MyToken",
@@ -74,8 +71,6 @@ describe("get_hts_balance (non-custodial)", () => {
         decimals: 0,
       });
 
-      await wait(3000); // wait for tokens to be created
-
       // Transfer tokens to accounts
       await Promise.all([
         networkClientWrapper.transferToken(acc1.accountId, token1, 100),
@@ -84,8 +79,6 @@ describe("get_hts_balance (non-custodial)", () => {
         networkClientWrapper.transferToken(acc3.accountId, token1, 7),
         networkClientWrapper.transferToken(txExecutorAccount.accountId, token2, 17),
       ]);
-
-      await wait(3000); // wait for transfers to be completed
 
       hederaApiClient = new HederaMirrorNodeClient("testnet");
 

--- a/src/tests/non-custodial/get_hts_balance.test.ts
+++ b/src/tests/non-custodial/get_hts_balance.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { LangchainAgent } from "../utils/langchainAgent";
+import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
+import * as dotenv from "dotenv";
+import { NetworkClientWrapper } from "../utils/testnetClient";
+import { AccountData } from "../utils/testnetUtils";
+import { wait } from "../utils/utils";
+import { ExecutorAccountDetails } from "../../types";
+
+const IS_CUSTODIAL = false;
+
+const extractTokenBalance = (messages: any[]) => {
+  return messages.reduce((acc, { content }) => {
+    try {
+      const response = JSON.parse(content);
+
+      if (response.status === "error") {
+        throw new Error(response.message);
+      }
+
+      return String(response.balance);
+    } catch {
+      return acc;
+    }
+  }, "");
+};
+
+describe("get_hts_balance (non-custodial)", () => {
+  let acc1: AccountData;
+  let acc2: AccountData;
+  let acc3: AccountData;
+  let txExecutorAccount: AccountData;
+  let token1: string;
+  let token2: string;
+  let hederaApiClient: HederaMirrorNodeClient;
+  let testCases: [string, string, string][];
+
+  beforeAll(async () => {
+    dotenv.config();
+    try {
+      const networkClientWrapper = new NetworkClientWrapper(
+        process.env.HEDERA_ACCOUNT_ID!,
+        process.env.HEDERA_PRIVATE_KEY!,
+        process.env.HEDERA_KEY_TYPE!,
+        "testnet"
+      );
+
+      // Create accounts
+      await Promise.all([
+        networkClientWrapper.createAccount(0, -1),
+        networkClientWrapper.createAccount(0, -1),
+        networkClientWrapper.createAccount(0, -1),
+        networkClientWrapper.createAccount(0, -1),
+      ]).then(([_acc1, _acc2, _acc3, _acc4]) => {
+        acc1 = _acc1;
+        acc2 = _acc2;
+        acc3 = _acc3;
+        txExecutorAccount = _acc4;
+      });
+
+      // Create tokens
+      token1 = await networkClientWrapper.createFT({
+        name: "MyToken",
+        symbol: "MTK",
+        initialSupply: 1000,
+        decimals: 2,
+      });
+      token2 = await networkClientWrapper.createFT({
+        name: "MyToken2",
+        symbol: "MTK2",
+        initialSupply: 2000,
+        decimals: 0,
+      });
+
+      // Transfer tokens to accounts
+      await Promise.all([
+        networkClientWrapper.transferToken(acc1.accountId, token1, 100),
+        networkClientWrapper.transferToken(acc2.accountId, token2, 123),
+        networkClientWrapper.transferToken(acc3.accountId, token2, 10),
+        networkClientWrapper.transferToken(acc3.accountId, token1, 7),
+        networkClientWrapper.transferToken(txExecutorAccount.accountId, token2, 17),
+      ]);
+      await wait(5000);
+      hederaApiClient = new HederaMirrorNodeClient("testnet");
+
+      testCases = [
+        [
+          acc1.accountId,
+          token1,
+          `What's balance of token ${token1} for ${acc1.accountId}`,
+        ],
+        [
+          acc2.accountId,
+          token2,
+          `How many tokens with id ${token2} account ${acc2.accountId} has`,
+        ],
+        [
+          acc3.accountId,
+          token2,
+          `Check balance of token ${token2} for wallet ${acc3.accountId}`,
+        ],
+        [
+          acc1.accountId,
+          token2,
+          `What's balance of ${token2} for ${acc1.accountId}`,
+        ],
+        [
+          acc3.accountId,
+          token1,
+          `What is the token balance of ${token1} account ${acc3.accountId} has`,
+        ],
+        [
+          acc3.accountId,
+          token2,
+          `Check balance of token ${token2} for wallet ${acc3.accountId}`,
+        ],
+        [
+          txExecutorAccount.accountId,
+          token2,
+          `Whats my balance of token ${token2}`,
+        ],
+      ];
+    } catch (error) {
+      console.error("Error in setup:", error);
+      throw error;
+    }
+  });
+
+
+  /*
+  This action is not a typical non-custodial action. It does not require creation of any transaction, therefore no txBytes are returned.
+  This action fetches data from the hedera mirror node and returns the balances of all tokens for the given account.
+  If no account is provided, the Executor account is used by default in non-custodial flow, whereas in custodial flow, the operator account is used.
+  */
+  describe("balance checks", () => {
+    it("should test dynamic token balances", async () => {
+      for (const [accountId, tokenId, promptText] of testCases) {
+        const prompt = {
+          user: "user",
+          text: promptText,
+        };
+
+        const langchainAgent = await LangchainAgent.create();
+
+        console.log(`Prompt: ${promptText}`);
+        console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+        const executorAccountDetails: ExecutorAccountDetails = {
+          executorAccountId: txExecutorAccount.accountId,
+          executorPublicKey: txExecutorAccount.publicKey,
+        }
+
+        // STEP 1: send non-custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+        console.log(JSON.stringify(response, null, 2));
+
+        await wait(3000);
+
+        // STEP 2: extract balance
+        const hederaActionBalanceInDisplayUnits = extractTokenBalance(response.messages);
+
+        // STEP 3: verify with balance from hedera mirror node
+        const mirrorNodeBalanceInDisplayUnits = await hederaApiClient.getTokenBalance(
+          accountId,
+          tokenId
+        );
+
+        const mirrorNodeBalanceInBaseUnits = (await hederaApiClient.getAccountToken(
+          accountId,
+          tokenId
+        ))?.balance ?? 0;
+
+        const decimals = (await hederaApiClient.getTokenDetails(tokenId))?.decimals;
+        const hederaActionBalanceInBaseUnits = (Number(hederaActionBalanceInDisplayUnits) * 10 ** Number(decimals)).toFixed(0);
+
+        expect(String(hederaActionBalanceInDisplayUnits)).toEqual(String(mirrorNodeBalanceInDisplayUnits));
+        expect(hederaActionBalanceInBaseUnits).toEqual(String(mirrorNodeBalanceInBaseUnits));
+
+        await wait(3000);
+        console.log('\n\n');
+      }
+    });
+  });
+});

--- a/src/tests/non-custodial/get_hts_balance.test.ts
+++ b/src/tests/non-custodial/get_hts_balance.test.ts
@@ -152,7 +152,6 @@ describe("get_hts_balance (non-custodial)", () => {
 
         // STEP 1: send non-custodial prompt
         const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
-        console.log(JSON.stringify(response, null, 2));
 
         await wait(3000);
 

--- a/src/tests/non-custodial/get_list_of_token_holders.test.ts
+++ b/src/tests/non-custodial/get_list_of_token_holders.test.ts
@@ -101,8 +101,6 @@ describe("get_list_of_token_holders (non-custodial)", () => {
         token2 = t2;
       });
 
-      await wait(3000); // wait for tokens to be created
-
       await Promise.all([
         tokenCreatorAccountNetworkClientWrapper.transferToken(acc1.accountId, token1, 10), // base unit
         tokenCreatorAccountNetworkClientWrapper.transferToken(acc2.accountId, token1, 20),
@@ -112,8 +110,6 @@ describe("get_list_of_token_holders (non-custodial)", () => {
         tokenCreatorAccountNetworkClientWrapper.transferToken(acc3.accountId, token2, 60),
         tokenCreatorAccountNetworkClientWrapper.transferToken(txExecutorAccount.accountId, token2, 60),
       ]);
-
-      await wait(3000); // wait for tokens to be transferred
 
       testCases = [
         {

--- a/src/tests/non-custodial/get_list_of_token_holders.test.ts
+++ b/src/tests/non-custodial/get_list_of_token_holders.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import * as dotenv from "dotenv";
+import { NetworkClientWrapper } from "../utils/testnetClient";
+import { AccountData } from "../utils/testnetUtils";
+import { LangchainAgent } from "../utils/langchainAgent";
+import { ExecutorAccountDetails } from "../../types";
+
+interface TestCase {
+  promptText: string;
+  holders: { accountId: string; balance: string }[];
+}
+
+interface TokenData {
+  account: string;
+  balance: number;
+  decimals: number;
+}
+
+const IS_CUSTODIAL = false;
+
+const extractHoldersData = (messages: any[]): TokenData[] => {
+  const result = messages.reduce((acc, { content }) => {
+    try {
+      const response = JSON.parse(content);
+
+      return response.holders as TokenData[];
+    } catch {
+      return acc;
+    }
+  }, "");
+
+  if (!Array.isArray(result)) {
+    throw new Error("Holders not found");
+  }
+
+  return result;
+};
+
+describe("get_list_of_token_holders (non-custodial)", () => {
+  let acc1: AccountData;
+  let acc2: AccountData;
+  let acc3: AccountData;
+  let txExecutorAccount: AccountData;
+  let tokenCreatorAccount: AccountData;
+  let token1: string;
+  let token2: string;
+  let testCases: TestCase[];
+  let thresholdTestCases: TestCase[];
+  let networkClientWrapper: NetworkClientWrapper;
+
+  beforeAll(async () => {
+    dotenv.config();
+    try {
+      networkClientWrapper = new NetworkClientWrapper(
+        process.env.HEDERA_ACCOUNT_ID!,
+        process.env.HEDERA_PRIVATE_KEY!,
+        process.env.HEDERA_KEY_TYPE!,
+        "testnet"
+      );
+
+      await Promise.all([
+        networkClientWrapper.createAccount(0, -1),
+        networkClientWrapper.createAccount(0, -1),
+        networkClientWrapper.createAccount(0, -1),
+        networkClientWrapper.createAccount(0, -1),
+        networkClientWrapper.createAccount(30, -1), // the token creator account requires initial HBAR balance to pay transaction fees
+      ]).then(([account1, account2, account3, account4, account5]) => {
+        acc1 = account1;
+        acc2 = account2;
+        acc3 = account3;
+        txExecutorAccount = account4;
+        tokenCreatorAccount = account5;
+      });
+
+      const tokenCreatorAccountNetworkClientWrapper =
+        new NetworkClientWrapper(
+          tokenCreatorAccount.accountId,
+          tokenCreatorAccount.privateKey,
+          "ECDSA",
+          "testnet"
+        );
+
+      await Promise.all([
+        tokenCreatorAccountNetworkClientWrapper.createFT({
+          name: "MyToken1",
+          symbol: "MTK1",
+          initialSupply: 1000,
+          decimals: 2,
+        }),
+        tokenCreatorAccountNetworkClientWrapper.createFT({
+          name: "MyToken2",
+          symbol: "MTK2",
+          initialSupply: 1000, // base unit
+          decimals: 2,
+        }),
+      ]).then(([t1, t2]) => {
+        token1 = t1;
+        token2 = t2;
+      });
+
+      await Promise.all([
+        tokenCreatorAccountNetworkClientWrapper.transferToken(acc1.accountId, token1, 10), // base unit
+        tokenCreatorAccountNetworkClientWrapper.transferToken(acc2.accountId, token1, 20),
+        tokenCreatorAccountNetworkClientWrapper.transferToken(acc3.accountId, token1, 30),
+        tokenCreatorAccountNetworkClientWrapper.transferToken(acc1.accountId, token2, 40),
+        tokenCreatorAccountNetworkClientWrapper.transferToken(acc2.accountId, token2, 50),
+        tokenCreatorAccountNetworkClientWrapper.transferToken(acc3.accountId, token2, 60),
+        tokenCreatorAccountNetworkClientWrapper.transferToken(txExecutorAccount.accountId, token2, 60),
+      ]);
+
+      testCases = [
+        {
+          holders: [
+            { accountId: acc1.accountId, balance: "0.1" }, // balance is given in the display unit
+            { accountId: acc2.accountId, balance: "0.2" },
+            { accountId: acc3.accountId, balance: "0.3" },
+            {
+              accountId: tokenCreatorAccount.accountId,
+              balance: "9.4",
+            },
+          ],
+          promptText: `Who owns token ${token1} and what are their balances?`,
+        },
+        {
+          holders: [
+            { accountId: acc1.accountId, balance: "0.4" },
+            { accountId: acc2.accountId, balance: "0.5" },
+            { accountId: acc3.accountId, balance: "0.6" },
+            { accountId: txExecutorAccount.accountId, balance: "0.6" },
+            {
+              accountId: tokenCreatorAccount.accountId,
+              balance: "7.9",
+            },
+          ],
+          promptText: `Who owns token ${token2} and what are their balances?`,
+        },
+      ];
+
+      thresholdTestCases = [
+        {
+          holders: [
+            { accountId: acc3.accountId, balance: "0.3" },
+            {
+              accountId: tokenCreatorAccount.accountId,
+              balance: "9.4",
+            },
+          ],
+          promptText: `Which wallets hold token ${token1} and have at least 0.3 tokens?`,
+        },
+        {
+          holders: [
+            { accountId: acc3.accountId, balance: "0.6" },
+            { accountId: txExecutorAccount.accountId, balance: "0.6" },
+            {
+              accountId: tokenCreatorAccount.accountId,
+              balance: "7.9",
+            },
+          ],
+          promptText: `Show me the token holders for ${token2} with balances greater or equal 0.6.`,
+        },
+      ];
+    } catch (error) {
+      console.error("Error in setup:", error);
+      throw error;
+    }
+  });
+
+  /*
+  This action is not a typical non-custodial action. It does not require creation of any transaction, therefore, no txBytes are returned.
+  This action fetches data from the hedera mirror node and returns a list of holders for the given token.
+  */
+  describe("get list of token holders checks", () => {
+    it("should get list of token holders", async () => {
+      for (const { promptText, holders } of testCases) {
+        const prompt = {
+          user: "user",
+          text: promptText,
+        };
+
+        const langchainAgent = await LangchainAgent.create();
+
+        console.log(`Prompt: ${promptText}`);
+        console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+        const executorAccountDetails: ExecutorAccountDetails = {
+          executorAccountId: txExecutorAccount.accountId,
+          executorPublicKey: txExecutorAccount.publicKey,
+        }
+
+        // STEP 1: send non-custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+        console.log(JSON.stringify(response, null, 2));
+
+        // STEP 2: extract holders from response
+        const langchainResponseHolders = extractHoldersData(response.messages);
+        console.log(JSON.stringify(langchainResponseHolders, null, 2));
+
+        // STEP 3: verify the correctness
+        expect(langchainResponseHolders.length).toBe(holders.length);
+
+        langchainResponseHolders.forEach((holder) => {
+          const relevantHolder = holders.find(
+            (h) => h.accountId === holder.account
+          );
+          expect(relevantHolder?.balance).toEqual(holder.balance);
+          expect(relevantHolder?.accountId).toEqual(holder.account);
+        });
+
+        console.log('\n\n');
+      }
+    });
+
+    it("should get list of token holders with threshold", async () => {
+      for (const { promptText, holders } of thresholdTestCases) {
+        const prompt = {
+          user: "user",
+          text: promptText,
+        };
+        const langchainAgent = await LangchainAgent.create();
+
+        console.log(`Prompt: ${promptText}`);
+        console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+        const executorAccountDetails: ExecutorAccountDetails = {
+          executorAccountId: txExecutorAccount.accountId,
+          executorPublicKey: txExecutorAccount.publicKey,
+        }
+
+        // STEP 1: send non-custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+        // STEP 2: extract holders from response
+        const langchainResponseHolders = extractHoldersData(response.messages);
+
+        // STEP 3: verify the correctness
+        expect(langchainResponseHolders.length).toBe(holders.length);
+
+        langchainResponseHolders.forEach((holder) => {
+          const relevantHolder = holders.find(
+            (h) => h.accountId === holder.account
+          );
+          expect(relevantHolder?.balance).toEqual(holder.balance);
+          expect(relevantHolder?.accountId).toEqual(holder.account);
+        });
+
+        console.log('\n\n');
+      }
+    });
+  });
+});

--- a/src/tests/non-custodial/get_list_of_token_holders.test.ts
+++ b/src/tests/non-custodial/get_list_of_token_holders.test.ts
@@ -4,6 +4,7 @@ import { NetworkClientWrapper } from "../utils/testnetClient";
 import { AccountData } from "../utils/testnetUtils";
 import { LangchainAgent } from "../utils/langchainAgent";
 import { ExecutorAccountDetails } from "../../types";
+import { wait } from "../utils/utils";
 
 interface TestCase {
   promptText: string;
@@ -72,6 +73,8 @@ describe("get_list_of_token_holders (non-custodial)", () => {
         tokenCreatorAccount = account5;
       });
 
+      await wait(3000); // wait for accounts to be created
+
       const tokenCreatorAccountNetworkClientWrapper =
         new NetworkClientWrapper(
           tokenCreatorAccount.accountId,
@@ -98,6 +101,8 @@ describe("get_list_of_token_holders (non-custodial)", () => {
         token2 = t2;
       });
 
+      await wait(3000); // wait for tokens to be created
+
       await Promise.all([
         tokenCreatorAccountNetworkClientWrapper.transferToken(acc1.accountId, token1, 10), // base unit
         tokenCreatorAccountNetworkClientWrapper.transferToken(acc2.accountId, token1, 20),
@@ -107,6 +112,8 @@ describe("get_list_of_token_holders (non-custodial)", () => {
         tokenCreatorAccountNetworkClientWrapper.transferToken(acc3.accountId, token2, 60),
         tokenCreatorAccountNetworkClientWrapper.transferToken(txExecutorAccount.accountId, token2, 60),
       ]);
+
+      await wait(3000); // wait for tokens to be transferred
 
       testCases = [
         {

--- a/src/tests/non-custodial/get_pending_airdrops.test.ts
+++ b/src/tests/non-custodial/get_pending_airdrops.test.ts
@@ -4,7 +4,6 @@ import { LangchainAgent } from "../utils/langchainAgent";
 import { NetworkClientWrapper } from "../utils/testnetClient";
 import * as dotenv from "dotenv";
 import { Airdrop, ExecutorAccountDetails } from "../../types";
-import { wait } from "../utils/utils";
 
 const IS_CUSTODIAL = false;
 
@@ -65,8 +64,6 @@ describe("get_pending_airdrops (non-custodial)", () => {
                 airdropCreatorAccount = _acc5;
             });
 
-            await wait(3000); // wait for accounts to be created
-
             const airdropCreatorAccountNetworkClientWrapper =
               new NetworkClientWrapper(
                 airdropCreatorAccount.accountId,
@@ -82,8 +79,6 @@ describe("get_pending_airdrops (non-custodial)", () => {
                 initialSupply: 1000,
                 decimals: 2,
             });
-
-            await wait(3000); // wait for the token to be created
 
             // airdrop token
             await airdropCreatorAccountNetworkClientWrapper.airdropToken(token1, [
@@ -104,9 +99,6 @@ describe("get_pending_airdrops (non-custodial)", () => {
                     amount: 17,
                 },
             ]);
-
-            await wait(5000); // wait for the airdrop to be completed
-
 
             testCases = [
                 [

--- a/src/tests/non-custodial/get_pending_airdrops.test.ts
+++ b/src/tests/non-custodial/get_pending_airdrops.test.ts
@@ -65,6 +65,8 @@ describe("get_pending_airdrops (non-custodial)", () => {
                 airdropCreatorAccount = _acc5;
             });
 
+            await wait(3000); // wait for accounts to be created
+
             const airdropCreatorAccountNetworkClientWrapper =
               new NetworkClientWrapper(
                 airdropCreatorAccount.accountId,
@@ -80,6 +82,8 @@ describe("get_pending_airdrops (non-custodial)", () => {
                 initialSupply: 1000,
                 decimals: 2,
             });
+
+            await wait(3000); // wait for the token to be created
 
             // airdrop token
             await airdropCreatorAccountNetworkClientWrapper.airdropToken(token1, [
@@ -101,7 +105,7 @@ describe("get_pending_airdrops (non-custodial)", () => {
                 },
             ]);
 
-            await wait(5000);
+            await wait(5000); // wait for the airdrop to be completed
 
 
             testCases = [

--- a/src/tests/non-custodial/get_pending_airdrops.test.ts
+++ b/src/tests/non-custodial/get_pending_airdrops.test.ts
@@ -123,12 +123,12 @@ describe("get_pending_airdrops (non-custodial)", () => {
                     `Display pending airdrops for account ${acc3.accountId}`,
                     7,
                 ],
-                // [ // FIXME: this requires changes in default subject of the action
-                //     txExecutorAccount.accountId,
-                //     token1,
-                //     `Show my pending airdrops`,
-                //     17,
-                // ],
+                [
+                    txExecutorAccount.accountId,
+                    token1,
+                    `Show my pending airdrops`,
+                    17,
+                ],
             ];
 
         } catch (error) {
@@ -137,6 +137,12 @@ describe("get_pending_airdrops (non-custodial)", () => {
         }
     });
 
+
+    /*
+    This action is not a typical non-custodial action. It does not require creation of any transaction, therefore, no txBytes are returned.
+    This action fetches data from the hedera mirror node and returns pending airdrops for the given account.
+    If no account is provided, the Executor account is used by default in non-custodial flow, whereas in custodial flow, the operator account is used.
+    */
     describe("pending airdrops checks", () => {
         it("should test dynamic token airdrops", async () => {
             for (const [

--- a/src/tests/non-custodial/get_pending_airdrops.test.ts
+++ b/src/tests/non-custodial/get_pending_airdrops.test.ts
@@ -1,0 +1,191 @@
+import { describe, beforeAll, expect, it } from "vitest";
+import { AccountData } from "../utils/testnetUtils";
+import { LangchainAgent } from "../utils/langchainAgent";
+import { NetworkClientWrapper } from "../utils/testnetClient";
+import * as dotenv from "dotenv";
+import { Airdrop, ExecutorAccountDetails } from "../../types";
+import { wait } from "../utils/utils";
+
+const IS_CUSTODIAL = false;
+
+function findAirdrops(messages: any[]): Airdrop[] { 
+    const result = messages.reduce<Airdrop[] | null>((acc, message) => {
+        try {
+            const toolResponse = JSON.parse(message.content);
+            if (toolResponse.status === "success" && toolResponse.airdrop) {
+                return toolResponse.airdrop as Airdrop[];
+            }
+            return acc;
+        } catch (error) {
+            return acc;
+        }
+    }, null);
+
+    if (!result) {
+        throw new Error("No airdrops found");
+    }
+
+    return result;
+}
+
+describe("get_pending_airdrops (non-custodial)", () => {
+    let acc1: AccountData;
+    let acc2: AccountData;
+    let acc3: AccountData;
+    let txExecutorAccount: AccountData;
+    let airdropCreatorAccount: AccountData;
+    let token1: string;
+    let testCases: [string, string, string, number][];
+    let networkClientWrapper: NetworkClientWrapper;
+
+    beforeAll(async () => {
+        dotenv.config()
+        try {
+            networkClientWrapper = new NetworkClientWrapper(
+                process.env.HEDERA_ACCOUNT_ID!,
+                process.env.HEDERA_PRIVATE_KEY!,
+                process.env.HEDERA_KEY_TYPE!,
+                "testnet"
+            );
+
+            // create test accounts
+            const startingHbars = 0;
+            const autoAssociation = 0; // no auto association
+            await Promise.all([
+                networkClientWrapper.createAccount(startingHbars, autoAssociation),
+                networkClientWrapper.createAccount(startingHbars, autoAssociation),
+                networkClientWrapper.createAccount(startingHbars, autoAssociation),
+                networkClientWrapper.createAccount(startingHbars, autoAssociation),
+                networkClientWrapper.createAccount(20, autoAssociation), // airdrop creator account, with 20 hbars to cover gas costs
+            ]).then(([_acc1, _acc2, _acc3, _acc4, _acc5]) => {
+                acc1 = _acc1;
+                acc2 = _acc2;
+                acc3 = _acc3;
+                txExecutorAccount = _acc4;
+                airdropCreatorAccount = _acc5;
+            });
+
+            const airdropCreatorAccountNetworkClientWrapper =
+              new NetworkClientWrapper(
+                airdropCreatorAccount.accountId,
+                airdropCreatorAccount.privateKey,
+                "ECDSA",
+                "testnet"
+              );
+
+            // create token
+            token1 = await airdropCreatorAccountNetworkClientWrapper.createFT({
+                name: "AirDrop1",
+                symbol: "AD1",
+                initialSupply: 1000,
+                decimals: 2,
+            });
+
+            // airdrop token
+            await airdropCreatorAccountNetworkClientWrapper.airdropToken(token1, [
+                {
+                    accountId: acc1.accountId,
+                    amount: 10,
+                },
+                {
+                    accountId: acc2.accountId,
+                    amount: 10,
+                },
+                {
+                    accountId: acc3.accountId,
+                    amount: 7,
+                },
+                {
+                    accountId: txExecutorAccount.accountId,
+                    amount: 17,
+                },
+            ]);
+
+            await wait(5000);
+
+
+            testCases = [
+                [
+                    acc1.accountId,
+                    token1,
+                    `Show me pending airdrops for account ${acc1.accountId}`,
+                    10,
+                ],
+                [
+                    acc2.accountId,
+                    token1,
+                    `Get pending airdrops for account ${acc2.accountId}`,
+                    10,
+                ],
+                [
+                    acc3.accountId,
+                    token1,
+                    `Display pending airdrops for account ${acc3.accountId}`,
+                    7,
+                ],
+                // [ // FIXME: this requires changes in default subject of the action
+                //     txExecutorAccount.accountId,
+                //     token1,
+                //     `Show my pending airdrops`,
+                //     17,
+                // ],
+            ];
+
+        } catch (error) {
+            console.error("Error in setup:", error);
+            throw error;
+        }
+    });
+
+    describe("pending airdrops checks", () => {
+        it("should test dynamic token airdrops", async () => {
+            for (const [
+                accountId,
+                tokenId,
+                promptText,
+                expectedAmount,
+            ] of testCases) {
+                const prompt = {
+                    user: "user",
+                    text: promptText,
+                };
+
+                const langchainAgent = await LangchainAgent.create();
+
+                console.log(`Prompt: ${promptText}`);
+                console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+                const executorAccountDetails: ExecutorAccountDetails = {
+                    executorAccountId: txExecutorAccount.accountId,
+                    executorPublicKey: txExecutorAccount.publicKey,
+                }
+
+                // STEP 1: send non-custodial prompt
+                const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+                // STEP 2: extract airdrops from response
+                const airdrops = findAirdrops(response.messages);
+                const relevantAirdrop = airdrops.find((airdrop) => airdrop.receiver_id === accountId && airdrop.token_id === tokenId);
+
+                if (!relevantAirdrop) {
+                    throw new Error(`No matching airdrop found for account ${accountId} and token ${tokenId}`);
+                }
+
+                // STEP 3: verify the correctness
+                const expectedResult: Airdrop = {
+                    amount: expectedAmount,
+                    receiver_id: accountId,
+                    sender_id: airdropCreatorAccount.accountId,
+                    token_id: tokenId,
+                }
+
+                expect(relevantAirdrop.amount).toEqual(expectedResult.amount);
+                expect(relevantAirdrop.receiver_id).toEqual(expectedResult.receiver_id);
+                expect(relevantAirdrop.sender_id).toEqual(expectedResult.sender_id);
+                expect(relevantAirdrop.token_id).toEqual(expectedResult.token_id);
+
+                console.log('\n\n');
+            }
+        });
+    })
+})

--- a/src/tests/non-custodial/mint_nft.test.ts
+++ b/src/tests/non-custodial/mint_nft.test.ts
@@ -34,8 +34,6 @@ describe("hedera_mint_nft (non-custodial)", () => {
           0 // no auto association
         );
 
-        await wait(3000); // wait for accounts to be created
-
         executorCustodialClientWrapper = new NetworkClientWrapper(
           txExecutorAccount.accountId,
           txExecutorAccount.privateKey,
@@ -53,8 +51,6 @@ describe("hedera_mint_nft (non-custodial)", () => {
             symbol: "TTM",
             maxSupply: 1000,
         });
-
-        await wait(3000); // wait for the nft to be created
 
         const prompt = {
             user: "user",
@@ -84,7 +80,7 @@ describe("hedera_mint_nft (non-custodial)", () => {
           txExecutorAccount.accountId
         )
 
-        await wait(5000); // wait for tx to be executed
+        await wait(5000); // wait for the mirror node to update
 
         const tokenInfo =
             await hederaApiClient.getTokenDetails(tokenId);

--- a/src/tests/non-custodial/mint_nft.test.ts
+++ b/src/tests/non-custodial/mint_nft.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeAll, beforeEach } from "vitest";
+import { describe, expect, it, beforeAll } from "vitest";
 import { NetworkType} from "../types";
 import * as dotenv from "dotenv";
 import { NetworkClientWrapper } from "../utils/testnetClient";
@@ -34,6 +34,8 @@ describe("hedera_mint_nft (non-custodial)", () => {
           0 // no auto association
         );
 
+        await wait(3000); // wait for accounts to be created
+
         executorCustodialClientWrapper = new NetworkClientWrapper(
           txExecutorAccount.accountId,
           txExecutorAccount.privateKey,
@@ -41,12 +43,6 @@ describe("hedera_mint_nft (non-custodial)", () => {
           "testnet"
         );
     });
-
-    beforeEach(async () => {
-        dotenv.config();
-        await wait(3000);
-    });
-
 
     it("should mint non-fungible token", async () => {
         const STARTING_SUPPLY = 0;
@@ -57,6 +53,8 @@ describe("hedera_mint_nft (non-custodial)", () => {
             symbol: "TTM",
             maxSupply: 1000,
         });
+
+        await wait(3000); // wait for the nft to be created
 
         const prompt = {
             user: "user",

--- a/src/tests/non-custodial/mint_nft.test.ts
+++ b/src/tests/non-custodial/mint_nft.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, beforeAll, beforeEach } from "vitest";
+import { NetworkType} from "../types";
+import * as dotenv from "dotenv";
+import { NetworkClientWrapper } from "../utils/testnetClient";
+import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
+import { LangchainAgent } from "../utils/langchainAgent";
+import { extractTxBytes, signAndExecuteTx, wait } from "../utils/utils";
+import { AccountData } from "../utils/testnetUtils";
+import { ExecutorAccountDetails } from "../../types";
+
+dotenv.config();
+
+const IS_CUSTODIAL = false;
+
+describe("hedera_mint_nft (non-custodial)", () => {
+    let hederaApiClient: HederaMirrorNodeClient;
+    let networkClientWrapper: NetworkClientWrapper;
+    let executorCustodialClientWrapper: NetworkClientWrapper;
+    let txExecutorAccount: AccountData;
+
+
+    beforeAll(async () => {
+        hederaApiClient = new HederaMirrorNodeClient("testnet" as NetworkType);
+
+        networkClientWrapper = new NetworkClientWrapper(
+          process.env.HEDERA_ACCOUNT_ID!,
+          process.env.HEDERA_PRIVATE_KEY!,
+          process.env.HEDERA_KEY_TYPE!,
+          "testnet"
+        );
+
+        txExecutorAccount = await networkClientWrapper.createAccount(
+          5, // starting HBARs
+          0 // no auto association
+        );
+
+        executorCustodialClientWrapper = new NetworkClientWrapper(
+          txExecutorAccount.accountId,
+          txExecutorAccount.privateKey,
+          'ECDSA', // .createAccount() creates account with ECDSA key
+          "testnet"
+        );
+    });
+
+    beforeEach(async () => {
+        dotenv.config();
+        await wait(3000);
+    });
+
+
+    it("should mint non-fungible token", async () => {
+        const STARTING_SUPPLY = 0;
+
+        // STEP 0: create token that will be minted
+        const tokenId = await executorCustodialClientWrapper.createNFT({
+            name: "TokenToMint",
+            symbol: "TTM",
+            maxSupply: 1000,
+        });
+
+        const prompt = {
+            user: "user",
+            text: `Mint an NFT with metadata "My NFT" to token ${tokenId}`,
+        };
+
+        const langchainAgent = await LangchainAgent.create();
+
+        console.log(`Prompt: ${prompt.text}`);
+        console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+        const executorAccountDetails: ExecutorAccountDetails = {
+            executorAccountId: txExecutorAccount.accountId,
+            executorPublicKey: txExecutorAccount.publicKey,
+        }
+
+        // STEP 1: send non-custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+        // STEP 2: extract tx bytes
+        const txBytesString = extractTxBytes(response.messages)
+
+        // STEP 3: verify correctness by signing and executing the tx
+        const executedTx = await signAndExecuteTx(
+          txBytesString,
+          txExecutorAccount.privateKey,
+          txExecutorAccount.accountId
+        )
+
+        await wait(5000); // wait for tx to be executed
+
+        const tokenInfo =
+            await hederaApiClient.getTokenDetails(tokenId);
+
+
+        expect(Number(tokenInfo.total_supply)).toBe(STARTING_SUPPLY + 1);
+    });
+});

--- a/src/tests/non-custodial/mint_token.test.ts
+++ b/src/tests/non-custodial/mint_token.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeAll, beforeEach } from "vitest";
+import { describe, expect, it, beforeAll } from "vitest";
 import { NetworkType } from "../types";
 import * as dotenv from "dotenv";
 import { NetworkClientWrapper } from "../utils/testnetClient";
@@ -33,6 +33,8 @@ describe("hedera_mint_fungible_token (non-custodial)", () => {
         0 // no auto association
       );
 
+      await wait(3000); // wait for the account to be created
+
       executorCustodialClientWrapper = new NetworkClientWrapper(
         txExecutorAccount.accountId,
         txExecutorAccount.privateKey,
@@ -40,11 +42,6 @@ describe("hedera_mint_fungible_token (non-custodial)", () => {
         "testnet"
       );
     });
-
-  beforeEach(async () => {
-    dotenv.config();
-    await wait(3000);
-  });
 
   it("should mint fungible token", async () => {
     const STARTING_SUPPLY = 0;

--- a/src/tests/non-custodial/mint_token.test.ts
+++ b/src/tests/non-custodial/mint_token.test.ts
@@ -59,6 +59,8 @@ describe("hedera_mint_fungible_token (non-custodial)", () => {
       isSupplyKey: true,
     });
 
+    await wait(3000); // make sure the token is created
+
     const prompt = {
       user: "user",
       text: `Mint ${TOKENS_TO_MINT} of tokens ${tokenId}`,
@@ -76,6 +78,8 @@ describe("hedera_mint_fungible_token (non-custodial)", () => {
 
     // STEP 1: send non-custodial prompt
     const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+    console.log(JSON.stringify(response, null, 2));
 
     // STEP 2: extract tx bytes
     const txBytesString = extractTxBytes(response.messages)
@@ -108,6 +112,8 @@ describe("hedera_mint_fungible_token (non-custodial)", () => {
       initialSupply: STARTING_SUPPLY,
     });
 
+    await wait(3000); // make sure the token is created
+
     const prompt = {
       user: "user",
       text: `Mint ${TOKENS_TO_MINT} of tokens ${tokenId}`,
@@ -125,6 +131,8 @@ describe("hedera_mint_fungible_token (non-custodial)", () => {
 
     // STEP 1: send non-custodial prompt
     const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+    console.log(JSON.stringify(response, null, 2));
 
     // STEP 2: extract tx bytes
     const txBytesString = extractTxBytes(response.messages)
@@ -161,6 +169,8 @@ describe("hedera_mint_fungible_token (non-custodial)", () => {
       isSupplyKey: true,
     });
 
+    await wait(3000); // make sure the token is created
+
     const prompt = {
       user: "user",
       text: `Mint ${TOKENS_TO_MINT_IN_DISPLAY_UNITS} of tokens ${tokenId}`,
@@ -178,6 +188,8 @@ describe("hedera_mint_fungible_token (non-custodial)", () => {
 
     // STEP 1: send non-custodial prompt
     const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+    console.log(JSON.stringify(response, null, 2));
 
     // STEP 2: extract tx bytes
     const txBytesString = extractTxBytes(response.messages)

--- a/src/tests/non-custodial/mint_token.test.ts
+++ b/src/tests/non-custodial/mint_token.test.ts
@@ -33,8 +33,6 @@ describe("hedera_mint_fungible_token (non-custodial)", () => {
         0 // no auto association
       );
 
-      await wait(3000); // wait for the account to be created
-
       executorCustodialClientWrapper = new NetworkClientWrapper(
         txExecutorAccount.accountId,
         txExecutorAccount.privateKey,
@@ -55,8 +53,6 @@ describe("hedera_mint_fungible_token (non-custodial)", () => {
       initialSupply: STARTING_SUPPLY,
       isSupplyKey: true,
     });
-
-    await wait(3000); // make sure the token is created
 
     const prompt = {
       user: "user",
@@ -88,7 +84,7 @@ describe("hedera_mint_fungible_token (non-custodial)", () => {
       txExecutorAccount.accountId
     )
 
-    await wait(5000); // wait for tx to be executed
+    await wait(5000); // wait for the mirror node to update
 
     // STEP 4: verify that minting the token was successful
     const tokenInfo = await hederaApiClient.getTokenDetails(tokenId);
@@ -108,8 +104,6 @@ describe("hedera_mint_fungible_token (non-custodial)", () => {
       maxSupply: 1000,
       initialSupply: STARTING_SUPPLY,
     });
-
-    await wait(3000); // make sure the token is created
 
     const prompt = {
       user: "user",
@@ -143,7 +137,7 @@ describe("hedera_mint_fungible_token (non-custodial)", () => {
       )
     ).rejects.toThrow("TOKEN_HAS_NO_SUPPLY_KEY");
 
-    await wait(5000); // wait for tx to be executed
+    await wait(5000); // wait for the mirror node to update
 
     // STEP 4: verify that minting the token was successful
     const tokenInfo = await hederaApiClient.getTokenDetails(tokenId);
@@ -165,8 +159,6 @@ describe("hedera_mint_fungible_token (non-custodial)", () => {
       initialSupply: STARTING_SUPPLY, // given in base units
       isSupplyKey: true,
     });
-
-    await wait(3000); // make sure the token is created
 
     const prompt = {
       user: "user",
@@ -197,8 +189,7 @@ describe("hedera_mint_fungible_token (non-custodial)", () => {
       txExecutorAccount.privateKey,
       txExecutorAccount.accountId
     )
-
-    await wait(5000); // wait for tx to be executed
+    await wait(5000); // wait for the mirror node to update
 
     // STEP 4: verify that minting the token was successful
     const tokenInfo = await hederaApiClient.getTokenDetails(tokenId);

--- a/src/tests/non-custodial/mint_token.test.ts
+++ b/src/tests/non-custodial/mint_token.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, beforeAll, beforeEach } from "vitest";
+import { NetworkType } from "../types";
+import * as dotenv from "dotenv";
+import { NetworkClientWrapper } from "../utils/testnetClient";
+import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
+import { LangchainAgent } from "../utils/langchainAgent";
+import { extractTxBytes, signAndExecuteTx, wait } from "../utils/utils";
+import { AccountData } from "../utils/testnetUtils";
+import { ExecutorAccountDetails } from "../../types";
+
+dotenv.config();
+
+const IS_CUSTODIAL = false;
+
+describe("hedera_mint_fungible_token (non-custodial)", () => {
+  let hederaApiClient: HederaMirrorNodeClient;
+  let networkClientWrapper: NetworkClientWrapper;
+  let executorCustodialClientWrapper: NetworkClientWrapper;
+  let txExecutorAccount: AccountData;
+
+    beforeAll(async () => {
+      hederaApiClient = new HederaMirrorNodeClient("testnet" as NetworkType);
+
+      networkClientWrapper = new NetworkClientWrapper(
+        process.env.HEDERA_ACCOUNT_ID!,
+        process.env.HEDERA_PRIVATE_KEY!,
+        process.env.HEDERA_KEY_TYPE!,
+        "testnet"
+      );
+
+      txExecutorAccount = await networkClientWrapper.createAccount(
+        15, // starting HBARs
+        0 // no auto association
+      );
+
+      executorCustodialClientWrapper = new NetworkClientWrapper(
+        txExecutorAccount.accountId,
+        txExecutorAccount.privateKey,
+        'ECDSA', // .createAccount() creates account with ECDSA key
+        "testnet"
+      );
+    });
+
+  beforeEach(async () => {
+    dotenv.config();
+    await wait(3000);
+  });
+
+  it("should mint fungible token", async () => {
+    const STARTING_SUPPLY = 0;
+    const TOKENS_TO_MINT = 100;
+
+    // STEP 0: create token that will be minted
+    const tokenId = await executorCustodialClientWrapper.createFT({
+      name: "TokenToMint",
+      symbol: "TTM",
+      maxSupply: 1000,
+      initialSupply: STARTING_SUPPLY,
+      isSupplyKey: true,
+    });
+
+    const prompt = {
+      user: "user",
+      text: `Mint ${TOKENS_TO_MINT} of tokens ${tokenId}`,
+    };
+
+    const langchainAgent = await LangchainAgent.create();
+
+    console.log(`Prompt: ${prompt.text}`);
+    console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+    const executorAccountDetails: ExecutorAccountDetails = {
+      executorAccountId: txExecutorAccount.accountId,
+      executorPublicKey: txExecutorAccount.publicKey,
+    }
+
+    // STEP 1: send non-custodial prompt
+    const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+    // STEP 2: extract tx bytes
+    const txBytesString = extractTxBytes(response.messages)
+
+    // STEP 3: verify correctness by signing and executing the tx
+    const executedTx = await signAndExecuteTx(
+      txBytesString,
+      txExecutorAccount.privateKey,
+      txExecutorAccount.accountId
+    )
+
+    await wait(5000); // wait for tx to be executed
+
+    // STEP 4: verify that minting the token was successful
+    const tokenInfo = await hederaApiClient.getTokenDetails(tokenId);
+
+    expect(Number(tokenInfo.total_supply)).toBe(
+      STARTING_SUPPLY + TOKENS_TO_MINT
+    );
+  });
+
+  it("should fail minting fungible tokens due to not setting supply key of token", async () => {
+    const STARTING_SUPPLY = 0;
+    const TOKENS_TO_MINT = 100;
+
+    const tokenId = await executorCustodialClientWrapper.createFT({
+      name: "TokenToMint",
+      symbol: "TTM",
+      maxSupply: 1000,
+      initialSupply: STARTING_SUPPLY,
+    });
+
+    const prompt = {
+      user: "user",
+      text: `Mint ${TOKENS_TO_MINT} of tokens ${tokenId}`,
+    };
+
+    const langchainAgent = await LangchainAgent.create();
+
+    console.log(`Prompt: ${prompt.text}`);
+    console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+    const executorAccountDetails: ExecutorAccountDetails = {
+      executorAccountId: txExecutorAccount.accountId,
+      executorPublicKey: txExecutorAccount.publicKey,
+    }
+
+    // STEP 1: send non-custodial prompt
+    const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+    // STEP 2: extract tx bytes
+    const txBytesString = extractTxBytes(response.messages)
+
+    // STEP 3: verify correctness by signing and executing the tx
+    await expect(
+      signAndExecuteTx(
+        txBytesString,
+        txExecutorAccount.privateKey,
+        txExecutorAccount.accountId
+      )
+    ).rejects.toThrow("TOKEN_HAS_NO_SUPPLY_KEY");
+
+    await wait(5000); // wait for tx to be executed
+
+    // STEP 4: verify that minting the token was successful
+    const tokenInfo = await hederaApiClient.getTokenDetails(tokenId);
+
+    expect(Number(tokenInfo.total_supply)).toBe(STARTING_SUPPLY);
+
+  });
+
+  it("should mint fungible token using display units in prompt", async () => {
+    const STARTING_SUPPLY = 0;
+    const TOKENS_TO_MINT_IN_DISPLAY_UNITS = 100;
+    const DECIMALS = 2;
+
+    const tokenId = await executorCustodialClientWrapper.createFT({
+      name: "TokenToMint",
+      symbol: "TTM",
+      maxSupply: 100_000_000, // given in base units. This is 1_000_000 tokens in display units
+      decimals: DECIMALS,
+      initialSupply: STARTING_SUPPLY, // given in base units
+      isSupplyKey: true,
+    });
+
+    const prompt = {
+      user: "user",
+      text: `Mint ${TOKENS_TO_MINT_IN_DISPLAY_UNITS} of tokens ${tokenId}`,
+    };
+
+    const langchainAgent = await LangchainAgent.create();
+
+    console.log(`Prompt: ${prompt.text}`);
+    console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+    const executorAccountDetails: ExecutorAccountDetails = {
+      executorAccountId: txExecutorAccount.accountId,
+      executorPublicKey: txExecutorAccount.publicKey,
+    }
+
+    // STEP 1: send non-custodial prompt
+    const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+    // STEP 2: extract tx bytes
+    const txBytesString = extractTxBytes(response.messages)
+
+    // STEP 3: verify correctness by signing and executing the tx
+    const executedTx = await signAndExecuteTx(
+      txBytesString,
+      txExecutorAccount.privateKey,
+      txExecutorAccount.accountId
+    )
+
+    await wait(5000); // wait for tx to be executed
+
+    // STEP 4: verify that minting the token was successful
+    const tokenInfo = await hederaApiClient.getTokenDetails(tokenId);
+
+    expect(Number(tokenInfo.total_supply) / Math.pow(10, DECIMALS)).toBe(
+      STARTING_SUPPLY / Math.pow(10, DECIMALS) + TOKENS_TO_MINT_IN_DISPLAY_UNITS
+    );
+  });
+});

--- a/src/tests/non-custodial/reject_token.test.ts
+++ b/src/tests/non-custodial/reject_token.test.ts
@@ -143,6 +143,8 @@ describe("reject_token (non-custodial)", async () => {
             );
 
             expect(tokenInfo?.balance ?? 0).toBe(0);
+
+            console.log('\n\n');
         }
     });
 });

--- a/src/tests/non-custodial/reject_token.test.ts
+++ b/src/tests/non-custodial/reject_token.test.ts
@@ -46,8 +46,6 @@ describe("reject_token (non-custodial)", async () => {
               -1 // unlimited auto association. To reject tokens, the airdrop must be first claimed.
             );
 
-            await wait(3000); // wait for accounts to be created
-
             airdropCreatorAccountNetworkClientWrapper = new NetworkClientWrapper(
                 airdropCreatorAccount.accountId,
                 airdropCreatorAccount.privateKey,
@@ -74,8 +72,6 @@ describe("reject_token (non-custodial)", async () => {
                 token2 = _token2;
             });
 
-            await wait(3000); // wait for tokens to be created
-
             // Define test cases using created accounts and tokens
             await Promise.all([
                 airdropCreatorAccountNetworkClientWrapper.airdropToken(token1, [
@@ -91,8 +87,6 @@ describe("reject_token (non-custodial)", async () => {
                     },
                 ]),
             ]);
-
-            await wait(3000); // wait for the airdrops to be completed
 
             testCases = [
                 {
@@ -141,7 +135,7 @@ describe("reject_token (non-custodial)", async () => {
               txExecutorAccount.accountId
             )
 
-            await wait(5000); // wait for tx to be executed
+            await wait(5000); // wait for the mirror node to update
 
             const tokenInfo = await hederaApiClient.getAccountToken(
                 networkClientWrapper.getAccountId(),

--- a/src/tests/non-custodial/reject_token.test.ts
+++ b/src/tests/non-custodial/reject_token.test.ts
@@ -46,6 +46,8 @@ describe("reject_token (non-custodial)", async () => {
               -1 // unlimited auto association. To reject tokens, the airdrop must be first claimed.
             );
 
+            await wait(3000); // wait for accounts to be created
+
             airdropCreatorAccountNetworkClientWrapper = new NetworkClientWrapper(
                 airdropCreatorAccount.accountId,
                 airdropCreatorAccount.privateKey,
@@ -72,6 +74,8 @@ describe("reject_token (non-custodial)", async () => {
                 token2 = _token2;
             });
 
+            await wait(3000); // wait for tokens to be created
+
             // Define test cases using created accounts and tokens
             await Promise.all([
                 airdropCreatorAccountNetworkClientWrapper.airdropToken(token1, [
@@ -87,6 +91,8 @@ describe("reject_token (non-custodial)", async () => {
                     },
                 ]),
             ]);
+
+            await wait(3000); // wait for the airdrops to be completed
 
             testCases = [
                 {

--- a/src/tests/non-custodial/reject_token.test.ts
+++ b/src/tests/non-custodial/reject_token.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
+import * as dotenv from "dotenv";
+import { NetworkClientWrapper } from "../utils/testnetClient";
+import { AccountData } from "../utils/testnetUtils";
+import {LangchainAgent} from "../utils/langchainAgent";
+import {NetworkType} from "../types";
+import { extractTxBytes, signAndExecuteTx, wait } from "../utils/utils";
+import { ExecutorAccountDetails } from "../../types";
+
+const IS_CUSTODIAL = false;
+
+describe("reject_token (non-custodial)", async () => {
+    let airdropCreatorAccount: AccountData;
+    let txExecutorAccount: AccountData;
+    let token1: string;
+    let token2: string;
+    let networkClientWrapper: NetworkClientWrapper;
+    let airdropCreatorAccountNetworkClientWrapper: NetworkClientWrapper;
+    let testCases: {
+        promptText: string;
+        tokenId: string;
+    }[];
+    let hederaApiClient: HederaMirrorNodeClient;
+
+    beforeAll(async () => {
+        dotenv.config();
+        try {
+            hederaApiClient = new HederaMirrorNodeClient("testnet" as NetworkType);
+
+            networkClientWrapper = new NetworkClientWrapper(
+              process.env.HEDERA_ACCOUNT_ID!,
+              process.env.HEDERA_PRIVATE_KEY!,
+              process.env.HEDERA_KEY_TYPE!,
+              "testnet"
+            );
+
+            // Create test accounts
+            airdropCreatorAccount = await networkClientWrapper.createAccount(
+              20, // starting HBARs
+              0 // no auto association
+            );
+
+            txExecutorAccount = await networkClientWrapper.createAccount(
+              5, // starting HBARs
+              -1 // unlimited auto association. To reject tokens, the airdrop must be first claimed.
+            );
+
+            airdropCreatorAccountNetworkClientWrapper = new NetworkClientWrapper(
+                airdropCreatorAccount.accountId,
+                airdropCreatorAccount.privateKey,
+                "ECDSA",
+                "testnet"
+            );
+
+            // Create test tokens
+            await Promise.all([
+                airdropCreatorAccountNetworkClientWrapper.createFT({
+                    name: "AirdropToken",
+                    symbol: "ADT",
+                    initialSupply: 10000000,
+                    decimals: 0,
+                }),
+                airdropCreatorAccountNetworkClientWrapper.createFT({
+                    name: "AirdropToken2",
+                    symbol: "ADT2",
+                    initialSupply: 10000,
+                    decimals: 0,
+                }),
+            ]).then(([_token1, _token2]) => {
+                token1 = _token1;
+                token2 = _token2;
+            });
+
+            // Define test cases using created accounts and tokens
+            await Promise.all([
+                airdropCreatorAccountNetworkClientWrapper.airdropToken(token1, [
+                    {
+                        accountId: txExecutorAccount.accountId,
+                        amount: 1,
+                    },
+                ]),
+                airdropCreatorAccountNetworkClientWrapper.airdropToken(token2, [
+                    {
+                        accountId: txExecutorAccount.accountId,
+                        amount: 1,
+                    },
+                ]),
+            ]);
+
+            testCases = [
+                {
+                    tokenId: token1,
+                    promptText: `Reject token ${token1}`,
+                },
+                {
+                    tokenId: token2,
+                    promptText: `Reject token ${token2}`,
+                },
+            ];
+
+        } catch (error) {
+            console.error("Error in setup:", error);
+            throw error;
+        }
+    });
+
+    it("it should reject token from account", async () => {
+        for (const { promptText, tokenId } of testCases) {
+            const prompt = {
+                user: "user",
+                text: promptText,
+            };
+
+            const langchainAgent = await LangchainAgent.create();
+
+            console.log(`Prompt: ${promptText}`);
+            console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+            const executorAccountDetails: ExecutorAccountDetails = {
+                executorAccountId: txExecutorAccount.accountId,
+                executorPublicKey: txExecutorAccount.publicKey,
+            }
+
+            // STEP 1: send non-custodial prompt
+            const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+            // STEP 2: extract tx bytes
+            const txBytesString = extractTxBytes(response.messages)
+
+            // STEP 3: verify correctness by signing and executing the tx
+            const executedTx = await signAndExecuteTx(
+              txBytesString,
+              txExecutorAccount.privateKey,
+              txExecutorAccount.accountId
+            )
+
+            await wait(5000); // wait for tx to be executed
+
+            const tokenInfo = await hederaApiClient.getAccountToken(
+                networkClientWrapper.getAccountId(),
+                tokenId
+            );
+
+            expect(tokenInfo?.balance ?? 0).toBe(0);
+        }
+    });
+});

--- a/src/tests/non-custodial/submit_topic_message.test.ts
+++ b/src/tests/non-custodial/submit_topic_message.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeAll, afterEach } from "vitest";
+import { describe, expect, it, beforeAll } from "vitest";
 import * as dotenv from "dotenv";
 import { NetworkClientWrapper } from "../utils/testnetClient";
 import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";

--- a/src/tests/non-custodial/submit_topic_message.test.ts
+++ b/src/tests/non-custodial/submit_topic_message.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, beforeAll, afterEach } from "vitest";
+import * as dotenv from "dotenv";
+import { NetworkClientWrapper } from "../utils/testnetClient";
+import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
+import { LangchainAgent } from "../utils/langchainAgent";
+import { extractTxBytes, signAndExecuteTx, wait } from "../utils/utils";
+import { AccountData } from "../utils/testnetUtils";
+import { ExecutorAccountDetails } from "../../types";
+
+const IS_CUSTODIAL = false;
+
+dotenv.config();
+describe("submit_topic_message (non-custodial)", () => {
+  let topic1: string;
+  let topic2: string;
+  let topic3: string;
+  const MESSAGE1: string = "Message1";
+  const MESSAGE2: string = "Message2";
+  const MESSAGE3: string = "Message3";
+  let testCases: { textPrompt: string; topicId: string; message: string }[];
+  let networkClientWrapper: NetworkClientWrapper;
+  let executorCustodialClientWrapper: NetworkClientWrapper;
+  let hederaApiClient: HederaMirrorNodeClient;
+  let txExecutorAccount: AccountData;
+
+  beforeAll(async () => {
+    try {
+      hederaApiClient = new HederaMirrorNodeClient("testnet");
+
+      networkClientWrapper = new NetworkClientWrapper(
+        process.env.HEDERA_ACCOUNT_ID!,
+        process.env.HEDERA_PRIVATE_KEY!,
+        process.env.HEDERA_KEY_TYPE!,
+        "testnet"
+      );
+
+      // Create a test account
+      const startingHbars = 60;
+      const autoAssociation = -1; // unlimited auto association
+      txExecutorAccount = await networkClientWrapper.createAccount(
+        startingHbars,
+        autoAssociation
+      );
+
+      // a custodial client wrapper for the tx executor account is required for creating topics before the test
+      executorCustodialClientWrapper = new NetworkClientWrapper(
+        txExecutorAccount.accountId,
+        txExecutorAccount.privateKey,
+        'ECDSA', // .createAccount() creates account with ECDSA key
+        "testnet"
+      );
+
+      await Promise.all([
+        executorCustodialClientWrapper.createTopic("Hello world 1", true),
+        executorCustodialClientWrapper.createTopic("Hello world 2", true),
+        executorCustodialClientWrapper.createTopic("Hello world 3", true),
+      ]).then(([_topic1, _topic2, _topic3]) => {
+        topic1 = _topic1.topicId;
+        topic2 = _topic2.topicId;
+        topic3 = _topic3.topicId;
+      });
+
+      testCases = [
+        {
+          textPrompt: `Submit message ${MESSAGE1} to topic ${topic1}`,
+          topicId: topic1,
+          message: MESSAGE1,
+        },
+        {
+          textPrompt: `Submit message ${MESSAGE2} to topic ${topic2}`,
+          topicId: topic2,
+          message: MESSAGE2,
+        },
+        {
+          textPrompt: `Submit message ${MESSAGE3} to topic ${topic3}`,
+          topicId: topic3,
+          message: MESSAGE3,
+        },
+      ];
+    } catch (error) {
+      console.error("Error in setup:", error);
+      throw error;
+    }
+  });
+
+  describe("submit topic message checks", () => {
+    it("should submit message to topic", async () => {
+      for (const { textPrompt, message, topicId } of testCases) {
+        const prompt = {
+          user: "user",
+          text: textPrompt,
+        };
+
+        const langchainAgent = await LangchainAgent.create();
+
+        console.log(`Prompt: ${textPrompt}`);
+        console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+        const executorAccountDetails: ExecutorAccountDetails = {
+          executorAccountId: txExecutorAccount.accountId,
+          executorPublicKey: txExecutorAccount.publicKey,
+        }
+
+        // STEP 1: send non-custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+        // STEP 2: extract tx bytes
+        const txBytesString = extractTxBytes(response.messages)
+
+        // STEP 3: verify correctness by signing and executing the tx
+        const executedTx = await signAndExecuteTx(
+          txBytesString,
+          txExecutorAccount.privateKey,
+          txExecutorAccount.accountId
+        )
+
+        await wait(5000); // wait for tx to be executed
+
+        // STEP 4: verify that the topic was deleted correctly
+        const topicMessages =
+          await hederaApiClient.getTopicMessages(topicId);
+
+        const receivedMessage = topicMessages.find(({ message: _message }) => {
+          return message === _message;
+        });
+
+        expect(receivedMessage).toBeTruthy();
+      }
+    });
+  });
+
+  afterEach(() => {
+    console.log("\n\n");
+  })
+
+});

--- a/src/tests/non-custodial/submit_topic_message.test.ts
+++ b/src/tests/non-custodial/submit_topic_message.test.ts
@@ -125,12 +125,9 @@ describe("submit_topic_message (non-custodial)", () => {
         });
 
         expect(receivedMessage).toBeTruthy();
+
+        console.log('\n\n');
       }
     });
   });
-
-  afterEach(() => {
-    console.log("\n\n");
-  })
-
 });

--- a/src/tests/non-custodial/submit_topic_message.test.ts
+++ b/src/tests/non-custodial/submit_topic_message.test.ts
@@ -60,6 +60,8 @@ describe("submit_topic_message (non-custodial)", () => {
         topic3 = _topic3.topicId;
       });
 
+      await wait(3000); // wait for accounts to be created
+
       testCases = [
         {
           textPrompt: `Submit message ${MESSAGE1} to topic ${topic1}`,

--- a/src/tests/non-custodial/submit_topic_message.test.ts
+++ b/src/tests/non-custodial/submit_topic_message.test.ts
@@ -60,8 +60,6 @@ describe("submit_topic_message (non-custodial)", () => {
         topic3 = _topic3.topicId;
       });
 
-      await wait(3000); // wait for accounts to be created
-
       testCases = [
         {
           textPrompt: `Submit message ${MESSAGE1} to topic ${topic1}`,
@@ -116,7 +114,7 @@ describe("submit_topic_message (non-custodial)", () => {
           txExecutorAccount.accountId
         )
 
-        await wait(5000); // wait for tx to be executed
+        await wait(5000); // wait for the mirror node to update
 
         // STEP 4: verify that the topic was deleted correctly
         const topicMessages =

--- a/src/tests/non-custodial/token_airdrop.test.ts
+++ b/src/tests/non-custodial/token_airdrop.test.ts
@@ -53,7 +53,7 @@ describe("Test Token Airdrop", async () => {
         txExecutorAccount = _acc6;
       });
 
-      await wait(5000);
+      await wait(3000); // wait for accounts to be created
 
       executorCustodialClientWrapper = new NetworkClientWrapper(
         txExecutorAccount.accountId,
@@ -87,6 +87,8 @@ describe("Test Token Airdrop", async () => {
         token2 = _token2;
         token3 = _token3;
       });
+
+      await wait(3000); // wait for tokens to be created
 
       // Define test cases using created accounts and tokens
       testCases = [
@@ -207,7 +209,6 @@ describe("Test Token Airdrop", async () => {
           )
         );
 
-        await wait(1000);
         console.log('\n\n');
       }
     });

--- a/src/tests/non-custodial/token_airdrop.test.ts
+++ b/src/tests/non-custodial/token_airdrop.test.ts
@@ -53,8 +53,6 @@ describe("Test Token Airdrop", async () => {
         txExecutorAccount = _acc6;
       });
 
-      await wait(3000); // wait for accounts to be created
-
       executorCustodialClientWrapper = new NetworkClientWrapper(
         txExecutorAccount.accountId,
         txExecutorAccount.privateKey,
@@ -88,8 +86,6 @@ describe("Test Token Airdrop", async () => {
         token3 = _token3;
       });
 
-      await wait(3000); // wait for tokens to be created
-
       // Define test cases using created accounts and tokens
       testCases = [
         [
@@ -118,7 +114,8 @@ describe("Test Token Airdrop", async () => {
         ],
       ];
 
-      await wait(5000);
+      await wait(5000); // wait for the mirror node to be updated with new accounts and tokens
+
     } catch (error) {
       console.error("Error in setup:", error);
       throw error;
@@ -173,7 +170,7 @@ describe("Test Token Airdrop", async () => {
           txExecutorAccount.accountId
         )
 
-        await wait(5000); // wait for tx to be executed
+        await wait(5000); // wait for the mirror node to update
 
         const balanceExecutorAfter = await hederaApiClient.getTokenBalance(
           executorAccountDetails.executorAccountId!,

--- a/src/tests/non-custodial/transfer_hbar.test.ts
+++ b/src/tests/non-custodial/transfer_hbar.test.ts
@@ -32,7 +32,7 @@ describe("Test HBAR transfer (non-custodial)", async () => {
       acc3 = await networkClientWrapper.createAccount(0);
       txExecutorAccount = await networkClientWrapper.createAccount(15); // set up with 15 HBARs
 
-      await wait(5000);
+      await wait(3000); // wait for accounts to be created
 
       hederaApiClient = new HederaMirrorNodeClient("testnet");
 
@@ -117,7 +117,6 @@ describe("Test HBAR transfer (non-custodial)", async () => {
           )
         ).toBeLessThanOrEqual(margin);
 
-        await wait(1000);
         console.log("\n\n");
       }
     });

--- a/src/tests/non-custodial/transfer_hbar.test.ts
+++ b/src/tests/non-custodial/transfer_hbar.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { LangchainAgent } from "../utils/langchainAgent";
+import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
+import * as dotenv from "dotenv";
+import { NetworkClientWrapper } from "../utils/testnetClient";
+import { AccountData } from "../utils/testnetUtils";
+import { extractTxBytes, formatTxHash, signAndExecuteTx, wait } from "../utils/utils";
+import { ExecutorAccountDetails } from "../../types";
+
+const IS_CUSTODIAL = false;
+
+describe("Test HBAR transfer (non-custodial)", async () => {
+  let acc1: AccountData;
+  let acc2: AccountData;
+  let acc3: AccountData;
+  let txExecutorAccount: AccountData;
+  let networkClientWrapper: NetworkClientWrapper;
+  let hederaApiClient: HederaMirrorNodeClient;
+  let testCases: [string, number, string][];
+
+  beforeAll(async () => {
+    dotenv.config();
+    try {
+      networkClientWrapper = new NetworkClientWrapper(
+        process.env.HEDERA_ACCOUNT_ID!,
+        process.env.HEDERA_PRIVATE_KEY!,
+        process.env.HEDERA_KEY_TYPE!,
+        "testnet"
+      );
+      acc1 = await networkClientWrapper.createAccount(0);
+      acc2 = await networkClientWrapper.createAccount(0);
+      acc3 = await networkClientWrapper.createAccount(0);
+      txExecutorAccount = await networkClientWrapper.createAccount(15); // set up with 15 HBARs
+
+      await wait(5000);
+
+      hederaApiClient = new HederaMirrorNodeClient("testnet");
+
+      testCases = [
+        [acc1.accountId, 1, `Transfer 1 HBAR to the account ${acc1.accountId}`],
+        [acc2.accountId, 0.5, `Send 0.5 HBAR to account ${acc2.accountId}.`],
+        [acc3.accountId, 3, `Transfer exactly 3 HBAR to ${acc3.accountId}.`],
+      ];
+    } catch (error) {
+      console.error("Error in setup:", error);
+      throw error;
+    }
+  });
+
+  describe("balance checks", () => {
+    it("should test dynamic HBAR transfers", async () => {
+      for (const [
+        receiversAccountId,
+        transferAmount,
+        promptText,
+      ] of testCases) {
+        const prompt = {
+          user: "user",
+          text: promptText,
+        };
+
+        const langchainAgent = await LangchainAgent.create();
+
+        console.log(`Prompt: ${promptText}`);
+        console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+        const executorAccountDetails: ExecutorAccountDetails = {
+          executorAccountId: txExecutorAccount.accountId,
+          executorPublicKey: txExecutorAccount.publicKey,
+        }
+
+        // STEP 0: get state before action call
+        const balanceExecutorBefore =
+          await hederaApiClient.getHbarBalance(executorAccountDetails.executorAccountId!);
+        const balanceReceiverBefore =
+          await hederaApiClient.getHbarBalance(receiversAccountId);
+
+        // STEP 1: send non-custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+        // STEP 2: extract tx bytes
+        const txBytesString = extractTxBytes(response.messages)
+
+        // STEP 3: verify correctness by signing and executing the tx
+        const executedTx = await signAndExecuteTx(
+          txBytesString,
+          txExecutorAccount.privateKey,
+          txExecutorAccount.accountId
+        )
+
+        await wait(5000); // wait for tx to be executed
+
+        // STEP 4: verify that the transfer was executed correctly
+        const balanceAgentAfter =
+          await hederaApiClient.getHbarBalance(executorAccountDetails.executorAccountId!);
+        const balanceReceiverAfter =
+          await hederaApiClient.getHbarBalance(receiversAccountId);
+
+        const txReport = await hederaApiClient.getTransactionReport(
+          formatTxHash(executedTx.txHash),
+          executorAccountDetails.executorAccountId!,
+          [receiversAccountId]
+        );
+
+        // Compare before and after including the difference due to paid fees
+        const margin = 0.5;
+        expect(txReport.status).toEqual("SUCCESS");
+        expect(
+          Math.abs(
+            balanceExecutorBefore -
+              (balanceAgentAfter + transferAmount + txReport.totalPaidFees)
+          )
+        ).toBeLessThanOrEqual(margin);
+        expect(
+          Math.abs(
+            balanceReceiverBefore - (balanceReceiverAfter - transferAmount)
+          )
+        ).toBeLessThanOrEqual(margin);
+
+        await wait(1000);
+        console.log("\n\n");
+      }
+    });
+  });
+});

--- a/src/tests/non-custodial/transfer_hbar.test.ts
+++ b/src/tests/non-custodial/transfer_hbar.test.ts
@@ -32,8 +32,6 @@ describe("Test HBAR transfer (non-custodial)", async () => {
       acc3 = await networkClientWrapper.createAccount(0);
       txExecutorAccount = await networkClientWrapper.createAccount(15); // set up with 15 HBARs
 
-      await wait(3000); // wait for accounts to be created
-
       hederaApiClient = new HederaMirrorNodeClient("testnet");
 
       testCases = [
@@ -41,6 +39,8 @@ describe("Test HBAR transfer (non-custodial)", async () => {
         [acc2.accountId, 0.5, `Send 0.5 HBAR to account ${acc2.accountId}.`],
         [acc3.accountId, 3, `Transfer exactly 3 HBAR to ${acc3.accountId}.`],
       ];
+
+      await wait(5000); // wait for the mirror node to be updated with new accounts
     } catch (error) {
       console.error("Error in setup:", error);
       throw error;
@@ -88,7 +88,7 @@ describe("Test HBAR transfer (non-custodial)", async () => {
           txExecutorAccount.accountId
         )
 
-        await wait(5000); // wait for tx to be executed
+        await wait(5000); // wait for the mirror node to update
 
         // STEP 4: verify that the transfer was executed correctly
         const balanceAgentAfter =

--- a/src/tests/non-custodial/transfer_hts.test.ts
+++ b/src/tests/non-custodial/transfer_hts.test.ts
@@ -44,8 +44,6 @@ describe("transfer_token_tool (non-custodial)", async () => {
         txExecutorAccount = _acc4;
       });
 
-      await wait(3000); // wait for accounts to be created
-
       // a custodial client wrapper for the tx executor account is required for creating tokens before the test
       executorCustodialClientWrapper = new NetworkClientWrapper(
         txExecutorAccount.accountId,
@@ -73,8 +71,6 @@ describe("transfer_token_tool (non-custodial)", async () => {
         token2 = _token2;
       });
 
-      await wait(3000); // wait for tokens to be created
-
       hederaApiClient = new HederaMirrorNodeClient("testnet");
 
       // Define test cases using created accounts and tokens
@@ -99,6 +95,8 @@ describe("transfer_token_tool (non-custodial)", async () => {
           `Transfer exactly 3 of token ${token1} to ${acc3.accountId}.`,
         ],
       ];
+
+      await wait(5000); // wait for the mirror node to be updated with new accounts and tokens
     } catch (error) {
       console.error("Error in setup:", error);
       throw error;
@@ -158,7 +156,7 @@ describe("transfer_token_tool (non-custodial)", async () => {
           txExecutorAccount.accountId
         )
 
-        await wait(5000); // wait for tx to be executed
+        await wait(5000); // wait for the mirror node to update
 
         // STEP 4: verify that the transfer was executed correctly
         const balanceExecutorAfterInDisplayUnits =

--- a/src/tests/non-custodial/transfer_hts.test.ts
+++ b/src/tests/non-custodial/transfer_hts.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { HederaMirrorNodeClient } from "../utils/hederaMirrorNodeClient";
+import * as dotenv from "dotenv";
+import { NetworkClientWrapper } from "../utils/testnetClient";
+import { AccountData } from "../utils/testnetUtils";
+import { LangchainAgent } from "../utils/langchainAgent";
+import { extractTxBytes, formatTxHash, signAndExecuteTx, wait } from "../utils/utils";
+import { ExecutorAccountDetails } from "../../types";
+
+const IS_CUSTODIAL = false;
+
+describe("transfer_token_tool (non-custodial)", async () => {
+  let acc1: AccountData;
+  let acc2: AccountData;
+  let acc3: AccountData;
+  let txExecutorAccount: AccountData;
+  let token1: string;
+  let token2: string;
+  let hederaApiClient: HederaMirrorNodeClient;
+  let networkClientWrapper: NetworkClientWrapper;
+  let executorCustodialClientWrapper: NetworkClientWrapper;
+  let testCases: [string, number, string, string][];
+
+  beforeAll(async () => {
+    dotenv.config();
+    try {
+      networkClientWrapper = new NetworkClientWrapper(
+        process.env.HEDERA_ACCOUNT_ID!,
+        process.env.HEDERA_PRIVATE_KEY!,
+        process.env.HEDERA_KEY_TYPE!,
+        "testnet"
+      );
+
+      // Create test accounts
+      await Promise.all([
+        networkClientWrapper.createAccount(0, -1),
+        networkClientWrapper.createAccount(0, -1),
+        networkClientWrapper.createAccount(0, -1),
+        networkClientWrapper.createAccount(30, -1), // txExecutorAccount needs to have 30 HBARs to pay for the tx gas
+      ]).then(([_acc1, _acc2, _acc3, _acc4]) => {
+        acc1 = _acc1;
+        acc2 = _acc2;
+        acc3 = _acc3;
+        txExecutorAccount = _acc4;
+      });
+
+      // a custodial client wrapper for the tx executor account is required for creating tokens before the test
+      executorCustodialClientWrapper = new NetworkClientWrapper(
+        txExecutorAccount.accountId,
+        txExecutorAccount.privateKey,
+        'ECDSA', // .createAccount() creates account with ECDSA key
+        "testnet"
+      );
+
+      // Create test tokens
+      await Promise.all([
+        executorCustodialClientWrapper.createFT({
+          name: "TestToken1",
+          symbol: "TT1",
+          initialSupply: 1000000,
+          decimals: 2,
+        }),
+        executorCustodialClientWrapper.createFT({
+          name: "TestToken2",
+          symbol: "TT2",
+          initialSupply: 2000,
+          decimals: 0,
+        }),
+      ]).then(([_token1, _token2]) => {
+        token1 = _token1;
+        token2 = _token2;
+      });
+
+      await wait(5000);
+
+      hederaApiClient = new HederaMirrorNodeClient("testnet");
+
+      // Define test cases using created accounts and tokens
+      // Operate on display units
+      testCases = [
+        [
+          acc1.accountId,
+          12.5,
+          token1,
+          `Transfer 12.5 tokens ${token1} to the account ${acc1.accountId}`,
+        ],
+        [
+          acc2.accountId,
+          10,
+          token2,
+          `Send 10 tokens ${token2} to account ${acc2.accountId}.`,
+        ],
+        [
+          acc3.accountId,
+          3,
+          token1,
+          `Transfer exactly 3 of token ${token1} to ${acc3.accountId}.`,
+        ],
+      ];
+    } catch (error) {
+      console.error("Error in setup:", error);
+      throw error;
+    }
+  });
+
+  describe("token transfers", () => {
+    it("should process token transfers for dynamically created accounts", async () => {
+      for (const [
+        receiversAccountId,
+        transferAmountInDisplayUnits,
+        tokenId,
+        promptText,
+      ] of testCases) {
+        const prompt = {
+          user: "user",
+          text: promptText,
+        };
+
+        const langchainAgent = await LangchainAgent.create();
+
+        console.log(`Prompt: ${promptText}`);
+        console.log(JSON.stringify(txExecutorAccount, null, 2));
+
+        const executorAccountDetails: ExecutorAccountDetails = {
+          executorAccountId: txExecutorAccount.accountId,
+          executorPublicKey: txExecutorAccount.publicKey,
+        }
+
+        // STEP 0: get state before action call
+        const balanceExecutorBeforeInDisplayUnits =
+          await hederaApiClient.getTokenBalance(executorAccountDetails.executorAccountId!, tokenId);
+        const balanceExecutorBeforeInBaseUnits = (
+          await hederaApiClient.getAccountToken(executorAccountDetails.executorAccountId!, tokenId)
+        )?.balance;
+
+        const balanceReceiverBeforeInDisplayUnits = await hederaApiClient.getTokenBalance(
+          receiversAccountId,
+          tokenId
+        );
+        const balanceReceiverBeforeInBaseUnits = (
+          await hederaApiClient.getAccountToken(receiversAccountId, tokenId)
+        )?.balance ?? 0;
+
+        const tokenDetails = await hederaApiClient.getTokenDetails(tokenId);
+
+        // STEP 1: send non-custodial prompt
+        const response = await langchainAgent.sendPrompt(prompt, IS_CUSTODIAL, executorAccountDetails);
+
+        // STEP 2: extract tx bytes
+        const txBytesString = extractTxBytes(response.messages)
+
+        // STEP 3: verify correctness by signing and executing the tx
+        const executedTx = await signAndExecuteTx(
+          txBytesString,
+          txExecutorAccount.privateKey,
+          txExecutorAccount.accountId
+        )
+
+        await wait(5000); // wait for tx to be executed
+
+        // STEP 4: verify that the transfer was executed correctly
+        const balanceExecutorAfterInDisplayUnits =
+          await hederaApiClient.getTokenBalance(executorAccountDetails.executorAccountId!, tokenId);
+        const balanceExecutorAfterInBaseUnits =
+          (await hederaApiClient.getAccountToken(executorAccountDetails.executorAccountId!, tokenId))
+            ?.balance ?? 0;
+
+        const balanceReceiverAfterInDisplayUnits =
+          await hederaApiClient.getTokenBalance(receiversAccountId, tokenId);
+        const balanceReceiverAfterInBaseUnits =
+          (await hederaApiClient.getAccountToken(receiversAccountId, tokenId))
+            ?.balance ?? 0;
+
+        const txReport = await hederaApiClient.getTransactionReport(
+          formatTxHash(executedTx.txHash),
+          executorAccountDetails.executorAccountId!,
+          [receiversAccountId]
+        );
+
+        // Compare before and after including the difference due to paid fees
+        expect(txReport.status).toEqual("SUCCESS");
+        // check if the balance is correct in display units
+        expect(balanceExecutorBeforeInDisplayUnits).toEqual(
+          balanceExecutorAfterInDisplayUnits + transferAmountInDisplayUnits
+        );
+        // check if the balance is correct in base units
+        expect(balanceExecutorBeforeInBaseUnits).toEqual(
+          balanceExecutorAfterInBaseUnits +
+            transferAmountInDisplayUnits * 10 ** Number(tokenDetails.decimals)
+        );
+        // check if the balance is correct in display units for receiver
+        expect(balanceReceiverBeforeInDisplayUnits).toEqual(
+          balanceReceiverAfterInDisplayUnits - transferAmountInDisplayUnits
+        );
+        // check if the balance is correct in base units for receiver
+        expect(balanceReceiverBeforeInBaseUnits).toEqual(
+          balanceReceiverAfterInBaseUnits -
+            transferAmountInDisplayUnits * 10 ** Number(tokenDetails.decimals)
+        );
+
+        await wait(1000);
+        console.log("\n\n");
+      }
+    });
+  });
+});

--- a/src/tests/non-custodial/transfer_hts.test.ts
+++ b/src/tests/non-custodial/transfer_hts.test.ts
@@ -44,6 +44,8 @@ describe("transfer_token_tool (non-custodial)", async () => {
         txExecutorAccount = _acc4;
       });
 
+      await wait(3000); // wait for accounts to be created
+
       // a custodial client wrapper for the tx executor account is required for creating tokens before the test
       executorCustodialClientWrapper = new NetworkClientWrapper(
         txExecutorAccount.accountId,
@@ -71,7 +73,7 @@ describe("transfer_token_tool (non-custodial)", async () => {
         token2 = _token2;
       });
 
-      await wait(5000);
+      await wait(3000); // wait for tokens to be created
 
       hederaApiClient = new HederaMirrorNodeClient("testnet");
 
@@ -198,7 +200,6 @@ describe("transfer_token_tool (non-custodial)", async () => {
             transferAmountInDisplayUnits * 10 ** Number(tokenDetails.decimals)
         );
 
-        await wait(1000);
         console.log("\n\n");
       }
     });

--- a/src/tests/types/index.ts
+++ b/src/tests/types/index.ts
@@ -101,7 +101,7 @@ export type Transaction = {
     bytes: null;
     charged_tx_fee: number;
     consensus_timestamp: string;
-    entity_id: null;
+    entity_id: string;
     max_fee: string;
     memo_base64: string;
     name: string;

--- a/src/tests/utils/testnetClient.ts
+++ b/src/tests/utils/testnetClient.ts
@@ -9,11 +9,16 @@ import {
   TopicId,
 } from "@hashgraph/sdk";
 import { AccountData, hederaPrivateKeyFromString } from "./testnetUtils";
-
 import HederaAgentKit from "../../agent";
 import { CreateFTOptions, CreateNFTOptions, HederaNetworkType } from "../../types";
-import { AirdropRecipient } from "../../tools/transactions/strategies";
-import { AirdropResult, CreateTokenResult, CreateTopicResult, SubmitMessageResult } from "../../tools";
+import {
+  AirdropResult,
+  AssociateTokenResult,
+  CreateTokenResult,
+  CreateTopicResult,
+  SubmitMessageResult,
+  AirdropRecipient
+} from "../../tools";
 
 export class NetworkClientWrapper {
   private readonly accountId: AccountId;
@@ -152,6 +157,19 @@ export class NetworkClientWrapper {
     return this.agentKit
       .submitTopicMessage(TopicId.fromString(topicId), message, isCustodial)
       .then(response => response.getRawResponse() as SubmitMessageResult);
+  }
+
+  /*
+  Associates token to the operator account.
+  @param tokenId - token id to associate
+  @returns AssociateTokenResult - response from the transaction
+   */
+  async associateToken(
+    tokenId: string,
+  ) : Promise<AssociateTokenResult> {
+    return this.agentKit
+      .associateToken(TokenId.fromString(tokenId), true)
+      .then(response => response.getRawResponse() as AssociateTokenResult);
   }
 
 }

--- a/src/tests/utils/utils.ts
+++ b/src/tests/utils/utils.ts
@@ -127,5 +127,14 @@ export const signAndExecuteTx = async (
     console.error("Error signing transaction:", JSON.stringify(error));
     throw error;
   }
-
 }
+
+export const formatTxHash = (txHash: string) => {
+  const [txId, txTimestamp] = txHash.split("@");
+
+  if (!txId || !txTimestamp) {
+    throw new Error("Invalid tx hash");
+  }
+
+  return `${txId}-${txTimestamp?.replace(".", "-")}`;
+};


### PR DESCRIPTION
adds:
- implements rest of the automated non-custodial tests
- implements `dissociate_token` custodial test that was missing