### PR TITLE
feat: refactor the custodial test approach

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -536,7 +536,7 @@ export class HederaAgentKit {
     private async associateTokenCustodial(
         tokenId: TokenId
     ): Promise<CustodialAssociateTokenResult> {
-        const response: AirdropResult = await HtsTransactionBuilder.associateToken(
+        const response: AssociateTokenResult = await HtsTransactionBuilder.associateToken(
             tokenId,
             this.accountId
         ).signAndExecute(this.client);

--- a/src/tests/non-custodial/associate_token.test.ts
+++ b/src/tests/non-custodial/associate_token.test.ts
@@ -124,7 +124,7 @@ describe("associate_token (non-custodial)", () => {
 
         await wait(5000); // wait for the mirror node to update the account info
 
-        // STEP 4: verify that token was associated
+        // STEP 4: verify that the token has been associated
         const token = await hederaMirrorNodeClient.getAccountToken(
           txExecutorAccount.accountId,
           tokenToAssociateId

--- a/src/tests/utils/hederaMirrorNodeClient.ts
+++ b/src/tests/utils/hederaMirrorNodeClient.ts
@@ -218,6 +218,8 @@ export class HederaMirrorNodeClient {
     ): Promise<AccountToken | undefined> {
         const url = `${this.baseUrl}/accounts/${accountId}/tokens?token.id=${tokenId}&limit=1&order=desc`;
 
+        console.log(`getAccountToken URL: ${url}`);
+
         const response = await fetch(url);
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);

--- a/src/tests/utils/langchainAgent.ts
+++ b/src/tests/utils/langchainAgent.ts
@@ -3,15 +3,29 @@ import { HumanMessage } from "@langchain/core/messages";
 import { initializeAgent } from "./utils";
 import { StateType } from "@langchain/langgraph";
 import { ExecutorAccountDetails } from "../../types";
+import { AccountData } from "./testnetUtils";
 
+/**
+ * Represents a LangchainAgent, providing functionalities to interact with the LangChain framework by utilizing agent
+ * invocation techniques and customizable configurations.
+ *
+ * **NOTE: This class is used for automatic tests only!**
+ */
 export class LangchainAgent {
   private constructor(
     private agent: ReturnType<typeof createReactAgent>,
     private config: { configurable: { thread_id: string } }
   ) {}
 
-  static async create(): Promise<LangchainAgent> {
-    const { agent, config } = await initializeAgent();
+  /**
+   * Creates a new instance of LangchainAgent by initializing an agent and configuration data.
+   *
+   * @param {AccountData} [operatorAccountData] - Optional account data required to initialize the agent.
+   * **If not passed, the agent for an account defined in the `.env` file will be created.**
+   * @return {Promise<LangchainAgent>} A promise that resolves to a new instance of LangchainAgent.
+   */
+  static async create(operatorAccountData?: AccountData): Promise<LangchainAgent> {
+    const { agent, config } = await initializeAgent(operatorAccountData);
     return new LangchainAgent(agent, config);
   }
 


### PR DESCRIPTION
refactor the custodial test approach to allow passing an operator account instead of running the actions with an account from the env file (CSS-210)

With this improvement, in each test an operator account is created to be the operator of langchain actions and their hedera-agent-kit. The account from the .env file is still required for funding other accounts creations but won't be spammed with token and topic created for test purposes.